### PR TITLE
Restrict minimum grid size from 2 cells to 3 cells in release flavour

### DIFF
--- a/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/preferences/ApplicationPreferencesImpl.kt
+++ b/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/preferences/ApplicationPreferencesImpl.kt
@@ -1,7 +1,10 @@
 package org.piepmeyer.gauguin.preferences
 
-import android.content.SharedPreferences
+import android.content.Context
 import androidx.core.content.edit
+import androidx.preference.PreferenceManager
+import org.koin.core.component.KoinComponent
+import org.piepmeyer.gauguin.R
 import org.piepmeyer.gauguin.Theme
 import org.piepmeyer.gauguin.options.DifficultySetting
 import org.piepmeyer.gauguin.options.DigitSetting
@@ -11,8 +14,10 @@ import org.piepmeyer.gauguin.options.NumeralSystem
 import org.piepmeyer.gauguin.options.SingleCageUsage
 
 class ApplicationPreferencesImpl(
-    val preferences: SharedPreferences,
-) : ApplicationPreferences {
+    private val androidContext: Context,
+) : KoinComponent, ApplicationPreferences {
+    private val preferences = PreferenceManager.getDefaultSharedPreferences(androidContext)
+
     override val theme: Theme
         get() {
             val themePref = preferences.getString("theme", Theme.DARK.name)!!
@@ -145,6 +150,18 @@ class ApplicationPreferencesImpl(
     override val gameVariant: GameOptionsVariant
         get() = loadIntoGameVariant()
 
+    override fun showFullscreen(): Boolean {
+        return preferences.getBoolean("showfullscreen", false)
+    }
+
+    override fun keepScreenOn(): Boolean {
+        return preferences.getBoolean("keepscreenon", true)
+    }
+
+    override fun showTimer(): Boolean {
+        return preferences.getBoolean("showtimer", true)
+    }
+
     private fun loadIntoGameVariant(): GameOptionsVariant {
         return GameOptionsVariant(
             showOperators(),
@@ -154,5 +171,19 @@ class ApplicationPreferencesImpl(
             singleCageUsage,
             numeralSystem,
         )
+    }
+
+    fun migrateGridSizeFromTwoToThree() {
+        if (androidContext.resources.getBoolean(R.bool.debuggable)) {
+            return
+        }
+
+        if (gridWidth == 2) {
+            gridWidth = 3
+        }
+
+        if (gridHeigth == 2) {
+            gridHeigth = 3
+        }
     }
 }

--- a/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/ActivityUtils.kt
+++ b/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/ActivityUtils.kt
@@ -6,14 +6,14 @@ import androidx.appcompat.app.AppCompatDelegate
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.piepmeyer.gauguin.Theme
-import org.piepmeyer.gauguin.preferences.ApplicationPreferencesImpl
+import org.piepmeyer.gauguin.preferences.ApplicationPreferences
 
-class ActivityUtils: KoinComponent {
-    private val applicationPreferences: ApplicationPreferencesImpl by inject()
+class ActivityUtils : KoinComponent {
+    private val applicationPreferences: ApplicationPreferences by inject()
 
     @Suppress("DEPRECATION")
     fun configureFullscreen(activity: Activity) {
-        if (!applicationPreferences.preferences.getBoolean("showfullscreen", false)) {
+        if (!applicationPreferences.showFullscreen()) {
             activity.window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
         } else {
             activity.window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
@@ -21,7 +21,7 @@ class ActivityUtils: KoinComponent {
     }
 
     fun configureKeepScreenOn(activity: Activity) {
-        if (applicationPreferences.preferences.getBoolean("keepscreenon", true)) {
+        if (applicationPreferences.keepScreenOn()) {
             activity.window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         } else {
             activity.window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)

--- a/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/grid/GridCellUIPossibleNumbersDrawer.kt
+++ b/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/grid/GridCellUIPossibleNumbersDrawer.kt
@@ -5,13 +5,13 @@ import android.graphics.Paint
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.piepmeyer.gauguin.options.NumeralSystem
-import org.piepmeyer.gauguin.preferences.ApplicationPreferencesImpl
+import org.piepmeyer.gauguin.preferences.ApplicationPreferences
 
 class GridCellUIPossibleNumbersDrawer(
     private val cellUI: GridCellUI,
-    private val paintHolder: GridPaintHolder
-): KoinComponent {
-    private val applicationPreferences: ApplicationPreferencesImpl by inject()
+    private val paintHolder: GridPaintHolder,
+) : KoinComponent {
+    private val applicationPreferences: ApplicationPreferences by inject()
     private val cell = cellUI.cell
 
     fun drawPossibleNumbers(
@@ -20,7 +20,7 @@ class GridCellUIPossibleNumbersDrawer(
         cellSize: Float,
         layoutDetails: GridLayoutDetails,
         fastFinishMode: Boolean,
-        numeralSystem: NumeralSystem
+        numeralSystem: NumeralSystem,
     ) {
         if (cell.possibles.isEmpty()) return
 
@@ -38,7 +38,7 @@ class GridCellUIPossibleNumbersDrawer(
         cellSize: Float,
         paint: Paint,
         layoutDetails: GridLayoutDetails,
-        numeralSystem: NumeralSystem
+        numeralSystem: NumeralSystem,
     ) {
         val possiblesLines = adaptTextSize(paint, cellSize, layoutDetails, numeralSystem)
 
@@ -51,7 +51,7 @@ class GridCellUIPossibleNumbersDrawer(
                 it,
                 cellUI.westPixel + layoutDetails.possibleNumbersMarginX(),
                 cellUI.northPixel + cellSize - layoutDetails.possibleNumbersMarginY() - lineHeigth * index,
-                paint
+                paint,
             )
             index++
         }
@@ -61,9 +61,9 @@ class GridCellUIPossibleNumbersDrawer(
         paint: Paint,
         cellSize: Float,
         layoutDetails: GridLayoutDetails,
-        numeralSystem: NumeralSystem
+        numeralSystem: NumeralSystem,
     ): List<String> {
-        for(textDivider in listOf(4f, 4.25f, 4.5f, 4.75f)) {
+        for (textDivider in listOf(4f, 4.25f, 4.5f, 4.75f)) {
             paint.textSize = (cellSize / textDivider).toInt().toFloat()
             val possiblesLines = calculatePossibleLines(paint, cellSize, layoutDetails, numeralSystem)
 
@@ -80,7 +80,7 @@ class GridCellUIPossibleNumbersDrawer(
         paint: Paint,
         cellSize: Float,
         layoutDetails: GridLayoutDetails,
-        numeralSystem: NumeralSystem
+        numeralSystem: NumeralSystem,
     ): List<String> {
         if (cellSize < 35) {
             return listOf("...")
@@ -88,10 +88,11 @@ class GridCellUIPossibleNumbersDrawer(
 
         val possiblesLines = mutableListOf<MutableSet<String>>()
 
-        //adds all possible to one line
-        var currentLine = cell.possibles.sorted()
-            .map { numeralSystem.displayableString(it) }
-            .toMutableSet()
+        // adds all possible to one line
+        var currentLine =
+            cell.possibles.sorted()
+                .map { numeralSystem.displayableString(it) }
+                .toMutableSet()
 
         possiblesLines += currentLine
         var currentLineText = getPossiblesLineText(currentLine)
@@ -118,7 +119,7 @@ class GridCellUIPossibleNumbersDrawer(
         cellSize: Float,
         paint: Paint,
         layoutDetails: GridLayoutDetails,
-        numeralSystem: NumeralSystem
+        numeralSystem: NumeralSystem,
     ) {
         paint.textSize = (cellSize / 4.75).toInt().toFloat()
         val xOffset = layoutDetails.possibleNumbersMarginX() * 2
@@ -131,7 +132,7 @@ class GridCellUIPossibleNumbersDrawer(
                 numeralSystem.displayableString(possible),
                 cellUI.westPixel + xOffset + index % 3 * layoutDetails.possiblesFixedGridDistanceX(),
                 cellUI.northPixel + yOffset + index / 3 * layoutDetails.possiblesFixedGridDistanceY(),
-                paint
+                paint,
             )
         }
     }

--- a/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/main/GameTopFragment.kt
+++ b/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/main/GameTopFragment.kt
@@ -18,16 +18,19 @@ import org.piepmeyer.gauguin.game.Game
 import org.piepmeyer.gauguin.game.GameLifecycle
 import org.piepmeyer.gauguin.game.GridCreationListener
 import org.piepmeyer.gauguin.game.PlayTimeListener
-import org.piepmeyer.gauguin.preferences.ApplicationPreferencesImpl
+import org.piepmeyer.gauguin.preferences.ApplicationPreferences
 import org.piepmeyer.gauguin.ui.difficulty.MainGameDifficultyLevelBalloon
 import org.piepmeyer.gauguin.ui.difficulty.MainGameDifficultyLevelFragment
 import kotlin.time.Duration
 
-class GameTopFragment : Fragment(R.layout.fragment_main_game_top), GridCreationListener,
-    PlayTimeListener, KoinComponent {
+class GameTopFragment :
+    Fragment(R.layout.fragment_main_game_top),
+    GridCreationListener,
+    PlayTimeListener,
+    KoinComponent {
     private val game: Game by inject()
     private val gameLifecycle: GameLifecycle by inject()
-    private val applicationPreferences: ApplicationPreferencesImpl by inject()
+    private val applicationPreferences: ApplicationPreferences by inject()
 
     private lateinit var binding: FragmentMainGameTopBinding
 
@@ -37,25 +40,27 @@ class GameTopFragment : Fragment(R.layout.fragment_main_game_top), GridCreationL
     override fun onCreateView(
         inflater: LayoutInflater,
         parent: ViewGroup?,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ): View {
         binding = FragmentMainGameTopBinding.inflate(inflater, parent, false)
 
-        val onClickListener = View.OnClickListener {
-            val difficulty = GameDifficultyRater().difficulty(game.grid)
+        val onClickListener =
+            View.OnClickListener {
+                val difficulty = GameDifficultyRater().difficulty(game.grid)
 
-            MainGameDifficultyLevelBalloon(difficulty, game.grid.variant).showBalloon(
-                baseView = it,
-                inflater = inflater,
-                parent = parent!!,
-                lifecycleOwner = this,
-                anchorView = if (binding.ratingStarThree.visibility == View.VISIBLE) {
-                    binding.ratingStarThree
-                } else {
-                    binding.difficulty
-                }
-            )
-        }
+                MainGameDifficultyLevelBalloon(difficulty, game.grid.variant).showBalloon(
+                    baseView = it,
+                    inflater = inflater,
+                    parent = parent!!,
+                    lifecycleOwner = this,
+                    anchorView =
+                        if (binding.ratingStarThree.visibility == View.VISIBLE) {
+                            binding.ratingStarThree
+                        } else {
+                            binding.difficulty
+                        },
+                )
+            }
 
         binding.difficulty.setOnClickListener(onClickListener)
         binding.ratingStarOne.setOnClickListener(onClickListener)
@@ -73,7 +78,7 @@ class GameTopFragment : Fragment(R.layout.fragment_main_game_top), GridCreationL
     }
 
     override fun onResume() {
-        this.showtimer = applicationPreferences.preferences.getBoolean("showtimer", true)
+        this.showtimer = applicationPreferences.showTimer()
         updateTimerVisibility()
 
         gameLifecycle.addPlayTimeListener(this)
@@ -81,7 +86,10 @@ class GameTopFragment : Fragment(R.layout.fragment_main_game_top), GridCreationL
         super.onResume()
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
         game.addGridCreationListener(this)
 
         freshGridWasCreated()
@@ -90,11 +98,12 @@ class GameTopFragment : Fragment(R.layout.fragment_main_game_top), GridCreationL
     }
 
     private fun updateTimerVisibility() {
-        binding.playtime.visibility = if (showtimer) {
-            View.VISIBLE
-        } else {
-            View.INVISIBLE
-        }
+        binding.playtime.visibility =
+            if (showtimer) {
+                View.VISIBLE
+            } else {
+                View.INVISIBLE
+            }
     }
 
     override fun freshGridWasCreated() {
@@ -106,17 +115,19 @@ class GameTopFragment : Fragment(R.layout.fragment_main_game_top), GridCreationL
             val rating = rater.byVariant(game.grid.variant)
             val difficulty = rater.difficulty(game.grid)
 
-            binding.difficulty.text = MainGameDifficultyLevelFragment.formatDifficulty(
-                DisplayableGameDifficulty(rating).displayableDifficulty(game.grid)
-            )
+            binding.difficulty.text =
+                MainGameDifficultyLevelFragment.formatDifficulty(
+                    DisplayableGameDifficulty(rating).displayableDifficulty(game.grid),
+                )
 
             setStarsByDifficulty(difficulty)
 
-            val visibilityOfStars = if (rating == null) {
-                View.GONE
-            } else {
-                View.VISIBLE
-            }
+            val visibilityOfStars =
+                if (rating == null) {
+                    View.GONE
+                } else {
+                    View.VISIBLE
+                }
 
             binding.ratingStarOne.visibility = visibilityOfStars
             binding.ratingStarTwo.visibility = visibilityOfStars
@@ -133,29 +144,29 @@ class GameTopFragment : Fragment(R.layout.fragment_main_game_top), GridCreationL
         setStarByDifficulty(
             binding.ratingStarOne,
             difficulty,
-            GameDifficulty.EASY
+            GameDifficulty.EASY,
         )
         setStarByDifficulty(
             binding.ratingStarTwo,
             difficulty,
-            GameDifficulty.MEDIUM
+            GameDifficulty.MEDIUM,
         )
         setStarByDifficulty(
             binding.ratingStarThree,
             difficulty,
-            GameDifficulty.HARD
+            GameDifficulty.HARD,
         )
         setStarByDifficulty(
             binding.ratingStarFour,
             difficulty,
-            GameDifficulty.EXTREME
+            GameDifficulty.EXTREME,
         )
     }
 
     private fun setStarByDifficulty(
         view: ImageView,
         difficulty: GameDifficulty,
-        minimumDifficulty: GameDifficulty
+        minimumDifficulty: GameDifficulty,
     ) {
         if (difficulty >= minimumDifficulty) {
             view.setImageResource(R.drawable.filled_star_20)

--- a/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/newgame/GridShapeOptionsFragment.kt
+++ b/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/newgame/GridShapeOptionsFragment.kt
@@ -12,17 +12,17 @@ import org.koin.core.component.inject
 import org.piepmeyer.gauguin.R
 import org.piepmeyer.gauguin.databinding.FragmentNewGameGridShapeOptionsBinding
 import org.piepmeyer.gauguin.grid.Grid
-import org.piepmeyer.gauguin.preferences.ApplicationPreferencesImpl
+import org.piepmeyer.gauguin.preferences.ApplicationPreferences
 import kotlin.math.min
 import kotlin.math.roundToInt
 
 class GridShapeOptionsFragment : Fragment(R.layout.fragment_new_game_grid_shape_options), KoinComponent {
-    private val applicationPreferences: ApplicationPreferencesImpl by inject()
+    private val applicationPreferences: ApplicationPreferences by inject()
     private var gridPreviewHolder: GridPreviewHolder? = null
     private var squareOnlyMode = false
     private var grid: Grid? = null
     private lateinit var binding: FragmentNewGameGridShapeOptionsBinding
-            
+
     fun setGridPreviewHolder(gridPreviewHolder: GridPreviewHolder) {
         this.gridPreviewHolder = gridPreviewHolder
     }
@@ -30,13 +30,16 @@ class GridShapeOptionsFragment : Fragment(R.layout.fragment_new_game_grid_shape_
     override fun onCreateView(
         inflater: LayoutInflater,
         parent: ViewGroup?,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ): View {
         binding = FragmentNewGameGridShapeOptionsBinding.inflate(inflater, parent, false)
         return binding.root
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
         binding.newGridPreview.isPreviewMode = true
         binding.newGridPreview.updateTheme()
         grid?.let {
@@ -44,30 +47,40 @@ class GridShapeOptionsFragment : Fragment(R.layout.fragment_new_game_grid_shape_
         }
         squareOnlyMode = applicationPreferences.squareOnlyGrid
 
-        binding.squareRectangularToggleGroup.check(if (squareOnlyMode) {
+        binding.squareRectangularToggleGroup.check(
+            if (squareOnlyMode) {
                 binding.squareButton.id
             } else {
                 binding.rectangularButton.id
-            }
+            },
         )
-        binding.squareRectangularToggleGroup.addOnButtonCheckedListener { _, checkedId, isChecked->
+        binding.squareRectangularToggleGroup.addOnButtonCheckedListener { _, checkedId, isChecked ->
             if (isChecked) {
                 squareOnlyChanged(checkedId == binding.squareButton.id)
             }
         }
 
+        if (resources.getBoolean(R.bool.debuggable)) {
+            binding.widthslider.valueFrom = 2f
+            binding.heigthslider.valueFrom = 2f
+        }
+
         binding.widthslider.value = applicationPreferences.gridWidth.toFloat()
         binding.heigthslider.value = applicationPreferences.gridHeigth.toFloat()
-        binding.widthslider.addOnChangeListener(Slider.OnChangeListener { _: Slider?, value: Float, _: Boolean ->
-            sizeSliderChanged(
-                value
-            )
-        })
-        binding.heigthslider.addOnChangeListener(Slider.OnChangeListener { _: Slider?, value: Float, _: Boolean ->
-            sizeSliderChanged(
-                value
-            )
-        })
+        binding.widthslider.addOnChangeListener(
+            Slider.OnChangeListener { _: Slider?, value: Float, _: Boolean ->
+                sizeSliderChanged(
+                    value,
+                )
+            },
+        )
+        binding.heigthslider.addOnChangeListener(
+            Slider.OnChangeListener { _: Slider?, value: Float, _: Boolean ->
+                sizeSliderChanged(
+                    value,
+                )
+            },
+        )
         setVisibilityOfHeightSlider(false)
     }
 
@@ -95,8 +108,9 @@ class GridShapeOptionsFragment : Fragment(R.layout.fragment_new_game_grid_shape_
     }
 
     private fun setVisibilityOfHeightSlider(animate: Boolean = true) {
-        if (animate)
+        if (animate) {
             TransitionManager.beginDelayedTransition(binding.root)
+        }
 
         if (squareOnlyMode) {
             binding.heigthslider.visibility = View.GONE
@@ -108,8 +122,9 @@ class GridShapeOptionsFragment : Fragment(R.layout.fragment_new_game_grid_shape_
     fun setGrid(grid: Grid) {
         this.grid = grid
 
-        if (this.isAdded)
+        if (this.isAdded) {
             updateGridPreview(grid)
+        }
     }
 
     fun updateNumeralSystem() {
@@ -122,13 +137,14 @@ class GridShapeOptionsFragment : Fragment(R.layout.fragment_new_game_grid_shape_
         binding.newGridPreview.grid = grid
         binding.newGridPreview.rebuildCellsFromGrid()
         binding.newGridPreview.invalidate()
-        binding.newGameGridSize.text = resources.getString(R.string.new_grid_shape_size).format(
+        binding.newGameGridSize.text =
+            resources.getString(R.string.new_grid_shape_size).format(
                 if (squareOnlyMode) {
                     grid.gridSize.width
                 } else {
                     "${grid.gridSize.width} x ${grid.gridSize.height}"
-                }
-        )
+                },
+            )
     }
 
     fun previewGridCalculated(grid: Grid) {

--- a/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/newgame/NewGameActivity.kt
+++ b/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/newgame/NewGameActivity.kt
@@ -15,11 +15,11 @@ import org.piepmeyer.gauguin.databinding.ActivityNewgameBinding
 import org.piepmeyer.gauguin.grid.Grid
 import org.piepmeyer.gauguin.grid.GridSize
 import org.piepmeyer.gauguin.options.GameVariant
-import org.piepmeyer.gauguin.preferences.ApplicationPreferencesImpl
+import org.piepmeyer.gauguin.preferences.ApplicationPreferences
 import org.piepmeyer.gauguin.ui.ActivityUtils
 
 class NewGameActivity : AppCompatActivity(), GridPreviewHolder, GridPreviewListener {
-    private val applicationPreferences: ApplicationPreferencesImpl by inject()
+    private val applicationPreferences: ApplicationPreferences by inject()
     private val activityUtils: ActivityUtils by inject()
     private val calculationService: GridCalculationService by inject()
 
@@ -86,13 +86,14 @@ class NewGameActivity : AppCompatActivity(), GridPreviewHolder, GridPreviewListe
         finishAfterTransition()
     }
 
-    private fun gameVariant(): GameVariant = GameVariant(
-        GridSize(
-            applicationPreferences.gridWidth,
-            applicationPreferences.gridHeigth
-        ),
-        applicationPreferences.gameVariant
-    )
+    private fun gameVariant(): GameVariant =
+        GameVariant(
+            GridSize(
+                applicationPreferences.gridWidth,
+                applicationPreferences.gridHeigth,
+            ),
+            applicationPreferences.gameVariant,
+        )
 
     override fun refreshGrid() {
         val variant = gameVariant()
@@ -106,7 +107,10 @@ class NewGameActivity : AppCompatActivity(), GridPreviewHolder, GridPreviewListe
         gridShapeOptionsFragment.updateNumeralSystem()
     }
 
-    override fun previewGridCreated(grid: Grid, previewStillCalculating: Boolean) {
+    override fun previewGridCreated(
+        grid: Grid,
+        previewStillCalculating: Boolean,
+    ) {
         runOnUiThread {
             grid.options.numeralSystem = applicationPreferences.gameVariant.numeralSystem
             gridShapeOptionsFragment.setGrid(grid)

--- a/gauguin-app/src/main/res/layout-sw600dp/fragment_new_game_grid_shape_options.xml
+++ b/gauguin-app/src/main/res/layout-sw600dp/fragment_new_game_grid_shape_options.xml
@@ -69,7 +69,7 @@
                 app:layout_constraintEnd_toStartOf="@id/newGameGridSize"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toTopOf="@id/squareRectangularToggleGroup"
-                android:valueFrom="2.0"
+                android:valueFrom="3.0"
                 android:valueTo="11.0"
                 android:stepSize="1.0"/>
 
@@ -81,7 +81,7 @@
                 app:layout_constraintEnd_toEndOf="@id/widthslider"
                 app:layout_constraintTop_toBottomOf="@id/widthslider"
                 app:layout_constraintBottom_toTopOf="@id/squareRectangularToggleGroup"
-                android:valueFrom="2.0"
+                android:valueFrom="3.0"
                 android:valueTo="11.0"
                 android:stepSize="1.0" />
 

--- a/gauguin-app/src/main/res/layout/fragment_new_game_grid_shape_options.xml
+++ b/gauguin-app/src/main/res/layout/fragment_new_game_grid_shape_options.xml
@@ -67,7 +67,7 @@
                 app:layout_constraintStart_toEndOf="@id/squareRectangularToggleGroup"
                 app:layout_constraintEnd_toStartOf="@id/newGameGridSize"
                 app:layout_constraintTop_toTopOf="parent"
-                android:valueFrom="2.0"
+                android:valueFrom="3.0"
                 android:valueTo="11.0"
                 android:stepSize="1.0"/>
 
@@ -79,7 +79,7 @@
                 app:layout_constraintEnd_toEndOf="@id/widthslider"
                 app:layout_constraintTop_toBottomOf="@id/widthslider"
                 app:layout_constraintBottom_toBottomOf="parent"
-                android:valueFrom="2.0"
+                android:valueFrom="3.0"
                 android:valueTo="11.0"
                 android:stepSize="1.0" />
 

--- a/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/preferences/ApplicationPreferences.kt
+++ b/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/preferences/ApplicationPreferences.kt
@@ -42,4 +42,10 @@ interface ApplicationPreferences {
     fun showOperators(): Boolean
 
     val gameVariant: GameOptionsVariant
+
+    fun showFullscreen(): Boolean
+
+    fun keepScreenOn(): Boolean
+
+    fun showTimer(): Boolean
 }


### PR DESCRIPTION
This is caused by problems when calculating grids of this size: Not every variant is possible to be calculated. Thus, this very small size gets out of the way - the size 3 is fully supported and calculable in every possible variant of options.

If a user has set its grid size to 2, it will be automatically shifted to 3. The debug flavour still allows grid size 2 as they are the smallest possible grid to test with.