### PR TITLE
Implement Android system based language settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add language choosing per system settings from Android 13 on.
+
 ### Changed
 
 ### Deprecated

--- a/gauguin-app/build.gradle.kts
+++ b/gauguin-app/build.gradle.kts
@@ -29,7 +29,6 @@ android {
         applicationId = "org.piepmeyer.gauguin"
         minSdk = 24
         targetSdk = 34
-        resourceConfigurations += setOf("en-rUS", "de-rDE")
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -88,6 +87,10 @@ android {
         disable += "ExpiredTargetSdkVersion"
     }
     namespace = "org.piepmeyer.gauguin"
+
+    androidResources {
+        generateLocaleConfig = true
+    }
 }
 
 play {

--- a/gauguin-app/src/main/res/resources.properties
+++ b/gauguin-app/src/main/res/resources.properties
@@ -1,0 +1,1 @@
+unqualifiedResLocale=en-US


### PR DESCRIPTION
Works from Android 13 on.

Refers to issue #119