### PR TITLE
Add new grid calculation algorithm

### DIFF
--- a/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/newgame/GridPreviewHolder.kt
+++ b/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/newgame/GridPreviewHolder.kt
@@ -4,4 +4,6 @@ interface GridPreviewHolder {
     fun refreshGrid()
 
     fun updateNumeralSystem()
+
+    fun clearGrids()
 }

--- a/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/newgame/GridShapeOptionsFragment.kt
+++ b/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/newgame/GridShapeOptionsFragment.kt
@@ -10,6 +10,7 @@ import com.google.android.material.slider.Slider
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.piepmeyer.gauguin.R
+import org.piepmeyer.gauguin.creation.GridCalculatorFactory
 import org.piepmeyer.gauguin.databinding.FragmentNewGameGridShapeOptionsBinding
 import org.piepmeyer.gauguin.grid.Grid
 import org.piepmeyer.gauguin.preferences.ApplicationPreferences
@@ -63,6 +64,12 @@ class GridShapeOptionsFragment : Fragment(R.layout.fragment_new_game_grid_shape_
         if (resources.getBoolean(R.bool.debuggable)) {
             binding.widthslider.valueFrom = 2f
             binding.heigthslider.valueFrom = 2f
+            binding.newGameNewAlgorithmSwitch.visibility = View.VISIBLE
+            binding.newGameNewAlgorithmSwitch.isChecked = GridCalculatorFactory.alwaysUseNewAlgorithm
+            binding.newGameNewAlgorithmSwitch.setOnCheckedChangeListener { _, isChecked ->
+                GridCalculatorFactory.alwaysUseNewAlgorithm = isChecked
+                gridPreviewHolder!!.clearGrids()
+            }
         }
 
         binding.widthslider.value = applicationPreferences.gridWidth.toFloat()

--- a/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/newgame/NewGameActivity.kt
+++ b/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/newgame/NewGameActivity.kt
@@ -110,6 +110,11 @@ class NewGameActivity : AppCompatActivity(), GridPreviewHolder, GridPreviewListe
         gridShapeOptionsFragment.updateNumeralSystem()
     }
 
+    override fun clearGrids() {
+        gridCalculator.clearGrids()
+        gridCalculator.calculateGrid(gameVariant(), lifecycleScope)
+    }
+
     override fun previewGridCreated(
         grid: Grid,
         previewStillCalculating: Boolean,

--- a/gauguin-app/src/main/res/layout-sw600dp/fragment_new_game_grid_shape_options.xml
+++ b/gauguin-app/src/main/res/layout-sw600dp/fragment_new_game_grid_shape_options.xml
@@ -22,7 +22,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/newGridPreview"
         app:layout_constraintBottom_toBottomOf="parent"
         style="?attr/materialCardViewElevatedStyle">
 
@@ -98,4 +98,19 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </com.google.android.material.card.MaterialCardView>
+
+    <com.google.android.material.materialswitch.MaterialSwitch
+        android:id="@+id/newGameNewAlgorithmSwitch"
+        style="@style/TextAppearance.Material3.LabelLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="16dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/newGameSizeCardView"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:text="New Algorithm"
+        android:visibility="gone"
+        />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/gauguin-app/src/main/res/layout/fragment_new_game_grid_shape_options.xml
+++ b/gauguin-app/src/main/res/layout/fragment_new_game_grid_shape_options.xml
@@ -24,7 +24,7 @@
         app:layout_constraintHeight_max="100dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/newGridPreview"
         style="?attr/materialCardViewElevatedStyle">
 
         <androidx.constraintlayout.widget.ConstraintLayout
@@ -96,4 +96,19 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </com.google.android.material.card.MaterialCardView>
+
+    <com.google.android.material.materialswitch.MaterialSwitch
+        android:id="@+id/newGameNewAlgorithmSwitch"
+        style="@style/TextAppearance.Material3.LabelLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="16dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/newGameSizeCardView"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:text="New Algorithm"
+        android:visibility="gone"
+        />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/gauguin-core/src/integrationTest/kotlin/org/piepmeyer/gauguin/creation/TestMergingCageGridCalculatorDistribution.kt
+++ b/gauguin-core/src/integrationTest/kotlin/org/piepmeyer/gauguin/creation/TestMergingCageGridCalculatorDistribution.kt
@@ -1,0 +1,108 @@
+package org.piepmeyer.gauguin.creation
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.kotest.core.spec.style.FunSpec
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import org.piepmeyer.gauguin.difficulty.GridDifficultyCalculator
+import org.piepmeyer.gauguin.grid.GridSize
+import org.piepmeyer.gauguin.options.DifficultySetting
+import org.piepmeyer.gauguin.options.DigitSetting
+import org.piepmeyer.gauguin.options.GameOptionsVariant
+import org.piepmeyer.gauguin.options.GameVariant
+import org.piepmeyer.gauguin.options.GridCageOperation
+import org.piepmeyer.gauguin.options.NumeralSystem
+import org.piepmeyer.gauguin.options.SingleCageUsage
+
+private val logger = KotlinLogging.logger {}
+
+class TestMergingCageGridCalculatorDistribution : FunSpec({
+    xtest("calculateValues 6x6") {
+        testHundredGrids(6)
+    }
+
+    xtest("calculateValues 9x9") {
+        testHundredGrids(9)
+    }
+}) {
+    companion object {
+        private fun testHundredGrids(size: Int) {
+            val difficultiesAndSingles =
+                runBlocking(Dispatchers.Default) {
+                    calculateDifficulties(size)
+                        .map {
+                            val value = it.await()
+                            value
+                        }
+                }
+
+            val sortedDifficulties = difficultiesAndSingles.map { it.first }.sorted()
+            val sortedSingles = difficultiesAndSingles.map { it.second }.sorted()
+
+            logger.info {
+                "Difficulties: minimum ${sortedDifficulties.min()}, " +
+                    "average ${sortedDifficulties.average()}, " +
+                    "maximum ${sortedDifficulties.max()}"
+            }
+            logger.info {
+                "Singles: minimum ${sortedSingles.min()}, " +
+                    "average ${sortedSingles.average()}, " +
+                    "maximum ${sortedSingles.max()}"
+            }
+
+            sortedSingles.groupingBy { it }.eachCount()
+                .forEach { (singles, count) ->
+                    logger.info { "singles $singles: $count" }
+                }
+        }
+
+        private suspend fun calculateDifficulties(size: Int): List<Deferred<Pair<Double, Int>>> =
+            kotlinx.coroutines.coroutineScope {
+                val deferreds = mutableListOf<Deferred<Pair<Double, Int>>>()
+
+                val variant =
+                    GameVariant(
+                        GridSize(size, size),
+                        GameOptionsVariant(
+                            true,
+                            GridCageOperation.OPERATIONS_ALL,
+                            DigitSetting.FIRST_DIGIT_ONE,
+                            DifficultySetting.ANY,
+                            SingleCageUsage.FIXED_NUMBER,
+                            NumeralSystem.Decimal,
+                        ),
+                    )
+
+                for (i in 0..99) {
+                    val randomizer = SeedRandomizerMock(i)
+                    val creator = MergingCageGridCalculator(variant, randomizer, RandomPossibleDigitsShuffler(randomizer.random))
+
+                    deferreds +=
+                        async(CoroutineName(variant.toString())) {
+                            calculateOneDifficulty(
+                                creator,
+                            )
+                        }
+                }
+
+                return@coroutineScope deferreds
+            }
+
+        private suspend fun calculateOneDifficulty(creator: MergingCageGridCalculator): Pair<Double, Int> {
+            val grid = creator.calculate()
+
+            val pair =
+                Pair(
+                    GridDifficultyCalculator(grid).calculate(),
+                    grid.cages.count { it.cells.size == 1 },
+                )
+
+            logger.info { "finished $pair" }
+
+            return pair
+        }
+    }
+}

--- a/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/CoreModule.kt
+++ b/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/CoreModule.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.runBlocking
 import org.koin.core.module.Module
 import org.koin.dsl.module
 import org.piepmeyer.gauguin.calculation.GridCalculationService
-import org.piepmeyer.gauguin.creation.RandomCageGridCalculator
+import org.piepmeyer.gauguin.creation.GridCalculatorFactory
 import org.piepmeyer.gauguin.game.Game
 import org.piepmeyer.gauguin.game.GameLifecycle
 import org.piepmeyer.gauguin.game.GameSolveService
@@ -76,7 +76,7 @@ class CoreModule(
         }
 
         return runBlocking {
-            val grid = RandomCageGridCalculator(initialGameVariant()).calculate()
+            val grid = GridCalculatorFactory().createCalculator(initialGameVariant()).calculate()
             grid.isActive = true
 
             grid

--- a/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/calculation/GridCalculationService.kt
+++ b/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/calculation/GridCalculationService.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import org.piepmeyer.gauguin.creation.RandomCageGridCalculator
+import org.piepmeyer.gauguin.creation.GridCalculatorFactory
 import org.piepmeyer.gauguin.grid.Grid
 import org.piepmeyer.gauguin.options.GameVariant
 
@@ -37,7 +37,7 @@ class GridCalculationService(
         scope.launch(dispatcher) {
             listeners.forEach { it.startingCurrentGridCalculation() }
 
-            val newGrid = RandomCageGridCalculator(variant).calculate()
+            val newGrid = GridCalculatorFactory().createCalculator(variant).calculate()
             invokeAfterNewGridWasCreated.invoke(newGrid)
 
             listeners.forEach { it.currentGridCalculated() }
@@ -50,7 +50,7 @@ class GridCalculationService(
         scope.launch(dispatcher) {
             listeners.forEach { it.startingNextGridCalculation() }
 
-            nextGrid = RandomCageGridCalculator(variant).calculate()
+            nextGrid = GridCalculatorFactory().createCalculator(variant).calculate()
 
             listeners.forEach { it.nextGridCalculated() }
         }

--- a/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/calculation/GridPreviewCalculationService.kt
+++ b/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/calculation/GridPreviewCalculationService.kt
@@ -8,8 +8,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
+import org.piepmeyer.gauguin.creation.GridCalculatorFactory
 import org.piepmeyer.gauguin.creation.GridCreator
-import org.piepmeyer.gauguin.creation.RandomCageGridCalculator
 import org.piepmeyer.gauguin.grid.Grid
 import org.piepmeyer.gauguin.options.DifficultySetting
 import org.piepmeyer.gauguin.options.GameVariant
@@ -83,7 +83,7 @@ class GridPreviewCalculationService(
             return it
         }
 
-        val grid = RandomCageGridCalculator(variant).calculate()
+        val grid = GridCalculatorFactory().createCalculator(variant).calculate()
         grids[variant] = grid
 
         return grid
@@ -95,5 +95,11 @@ class GridPreviewCalculationService(
 
     fun removeListener(listener: GridPreviewListener) {
         listeners.remove(listener)
+    }
+
+    fun clearGrids() {
+        grids.clear()
+        lastVariant = null
+        lastGridCalculation = null
     }
 }

--- a/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/creation/GridCalculator.kt
+++ b/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/creation/GridCalculator.kt
@@ -1,0 +1,7 @@
+package org.piepmeyer.gauguin.creation
+
+import org.piepmeyer.gauguin.grid.Grid
+
+fun interface GridCalculator {
+    suspend fun calculate(): Grid
+}

--- a/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/creation/GridCalculatorFactory.kt
+++ b/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/creation/GridCalculatorFactory.kt
@@ -1,0 +1,23 @@
+package org.piepmeyer.gauguin.creation
+
+import org.piepmeyer.gauguin.RandomSingleton
+import org.piepmeyer.gauguin.Randomizer
+import org.piepmeyer.gauguin.options.GameVariant
+
+class GridCalculatorFactory {
+    fun createCalculator(
+        variant: GameVariant,
+        randomizer: Randomizer = RandomSingleton.instance,
+        shuffler: PossibleDigitsShuffler = RandomPossibleDigitsShuffler(),
+    ): GridCalculator {
+        return if (variant.gridSize.isSquare && !alwaysUseNewAlgorithm) {
+            RandomCageGridCalculator(variant, randomizer, shuffler)
+        } else {
+            MergingCageGridCalculator(variant, randomizer, shuffler)
+        }
+    }
+
+    companion object {
+        var alwaysUseNewAlgorithm = false
+    }
+}

--- a/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/creation/MergingCageGridCalculator.kt
+++ b/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/creation/MergingCageGridCalculator.kt
@@ -1,0 +1,343 @@
+package org.piepmeyer.gauguin.creation
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.piepmeyer.gauguin.RandomSingleton
+import org.piepmeyer.gauguin.Randomizer
+import org.piepmeyer.gauguin.creation.cage.GridCageOperationDecider
+import org.piepmeyer.gauguin.creation.cage.GridCageResultCalculator
+import org.piepmeyer.gauguin.creation.cage.GridCageType
+import org.piepmeyer.gauguin.creation.cage.GridCageTypeLookup
+import org.piepmeyer.gauguin.creation.cage.GridSingleCageCreator
+import org.piepmeyer.gauguin.creation.dlx.DLX
+import org.piepmeyer.gauguin.creation.dlx.MathDokuDLX
+import org.piepmeyer.gauguin.creation.dlx.MathDokuDLXSolver
+import org.piepmeyer.gauguin.difficulty.GridDifficultyCalculator
+import org.piepmeyer.gauguin.grid.Grid
+import org.piepmeyer.gauguin.grid.GridCage
+import org.piepmeyer.gauguin.grid.GridCageAction
+import org.piepmeyer.gauguin.grid.GridCell
+import org.piepmeyer.gauguin.options.GameVariant
+import kotlin.math.abs
+import kotlin.time.measureTime
+
+private val logger = KotlinLogging.logger {}
+
+class MergingCageGridCalculator(
+    private val variant: GameVariant,
+    private val randomizer: Randomizer = RandomSingleton.instance,
+    private val shuffler: PossibleDigitsShuffler = RandomPossibleDigitsShuffler(),
+) : GridCalculator {
+    private var singleCageTries = 0
+    private var multiCageTries = 0
+    private var switchOperationTries = 0
+    private var switchOperations = 0
+
+    override suspend fun calculate(): Grid {
+        randomizer.discard()
+
+        val grid = Grid(variant)
+
+        randomiseGrid(grid)
+
+        createSingleCages(grid)
+
+        var runsWithoutSuccess = 0
+        var newGrid = grid
+
+        var singleCageMerges = 0
+
+        val mergeWithSingles =
+            measureTime {
+                while (runsWithoutSuccess < 3) {
+                    // val (lastSuccess, lastGrid) = mergeSingleCages(newGrid)
+                    val (lastSuccess, lastGrid) = mergeSingleCageWithNonSingleCages(newGrid)
+
+                    if (lastSuccess) {
+                        newGrid = lastGrid
+                        runsWithoutSuccess = 0
+                        singleCageMerges++
+                    } else {
+                        runsWithoutSuccess++
+                    }
+                }
+            }
+
+        runsWithoutSuccess = 0
+
+        var multiCageMerges = 0
+
+        val mergeNonSingles =
+            measureTime {
+                while (runsWithoutSuccess < 3) {
+                    val (lastSuccess, lastGrid) = mergeNonSingleCages(newGrid)
+
+                    if (lastSuccess) {
+                        newGrid = lastGrid
+                        runsWithoutSuccess = 0
+                        multiCageMerges++
+                    } else {
+                        runsWithoutSuccess++
+                    }
+                }
+            }
+
+        val difficulty = GridDifficultyCalculator(newGrid).calculate()
+
+        // switchOperations(newGrid)
+
+        logger.info {
+            "Applied $singleCageMerges single cage merges (tried $singleCageTries in $mergeWithSingles)" +
+                ", $multiCageMerges multi cage merges (tried $multiCageTries in $mergeNonSingles)" +
+                ", $switchOperations switch operations (tried $switchOperationTries)" +
+                " and difficulty $difficulty."
+        }
+
+        val newDifficulty = GridDifficultyCalculator(newGrid).calculate()
+        logger.info { "Difficulty after modification: $newDifficulty" }
+
+        return newGrid
+    }
+
+    private suspend fun switchOperations(grid: Grid) {
+        val shuffledCages =
+            grid.cages
+                .filter { it.cells.size > 1 }
+                .shuffled(randomizer.random())
+
+        shuffledCages.subList(0, shuffledCages.size / 1)
+            .forEach { cage ->
+                switchOperarionOfCage(grid, cage)
+            }
+    }
+
+    private suspend fun switchOperarionOfCage(
+        grid: Grid,
+        cage: GridCage,
+    ) {
+        val cageCreator = GridSingleCageCreator(grid.variant, cage)
+
+        val unmodifiedPossibleSize = cageCreator.possibleNums.size
+
+        var otherActions = GridCageAction.entries - GridCageAction.ACTION_NONE - cage.action
+
+        if (cage.cells.size != 2) {
+            otherActions = otherActions - GridCageAction.ACTION_DIVIDE - GridCageAction.ACTION_SUBTRACT
+        }
+
+        otherActions.forEach {
+            val newCage = GridCage.createWithCells(cage.id, grid, it, cage.cells[0], cage.cageType)
+            newCage.result = GridCageResultCalculator(newCage).calculateResultFromAction()
+
+            val newCageCreator = GridSingleCageCreator(grid.variant, newCage)
+
+            val possibleSize = newCageCreator.possibleNums.size
+
+            if (possibleSize > unmodifiedPossibleSize) {
+                grid.removeCage(cage)
+                grid.addCage(newCage)
+
+                newCage.cells.forEach { it.cage = newCage }
+
+                if (MathDokuDLX(grid).solve(DLX.SolveType.MULTIPLE) > 1) {
+                    grid.removeCage(newCage)
+                    grid.addCage(cage)
+
+                    cage.cells.forEach { it.cage = cage }
+
+                    switchOperationTries++
+                } else {
+                    switchOperations++
+                    return
+                }
+            }
+        }
+    }
+
+    private suspend fun mergeSingleCages(grid: Grid): Pair<Boolean, Grid> {
+        val singleCages = grid.cages.filter { it.cells.size == 1 }
+
+        singleCages.shuffled(randomizer.random()).forEach { cage ->
+            singleCages.shuffled(randomizer.random()).forEach { otherCage ->
+                if (cage != otherCage && grid.areAdjacent(cage, otherCage)) {
+                    val newCageCells = cage.cells + otherCage.cells
+
+                    val newGrid =
+                        createNewGridByMergingTwoCages(
+                            grid,
+                            cage,
+                            otherCage,
+                            newCageCells,
+                        )
+
+                    if (MathDokuDLXSolver().solve(newGrid) == 1) {
+                        return Pair(true, newGrid)
+                    }
+
+                    singleCageTries++
+                }
+            }
+        }
+
+        return Pair(false, grid)
+    }
+
+    private suspend fun mergeNonSingleCages(grid: Grid): Pair<Boolean, Grid> {
+        val cages = grid.cages
+
+        cages.shuffled(randomizer.random()).forEach { cage ->
+            cages.shuffled(randomizer.random()).forEach { otherCage ->
+                if (cage != otherCage && grid.areAdjacent(cage, otherCage) && cage.cells.size + otherCage.cells.size <= 4) {
+                    val cellsToBeMerged = cage.cells + otherCage.cells
+
+                    val gridCageType = GridCageTypeLookup(grid, cellsToBeMerged).lookupType()
+
+                    if (gridCageType != null) {
+                        val newGrid =
+                            createNewGridByMergingTwoCages(grid, cage, otherCage, cellsToBeMerged, gridCageType)
+
+                        if (MathDokuDLXSolver().solve(newGrid) == 1) {
+                            return Pair(true, newGrid)
+                        }
+
+                        multiCageTries++
+                    }
+                }
+            }
+        }
+
+        return Pair(false, grid)
+    }
+
+    private suspend fun mergeSingleCageWithNonSingleCages(grid: Grid): Pair<Boolean, Grid> {
+        val singleCages = grid.cages.filter { it.cells.size == 1 }
+        val cages = grid.cages
+
+        /*val singleCagesOrdered =
+            singleCages.filter { singleCage -> grid.cages.count { grid.areAdjacent(singleCage, it) } <= 2 }
+                .shuffled(randomizer.random()) +
+                singleCages.filter { singleCage -> grid.cages.count { grid.areAdjacent(singleCage, it) } > 2 }
+                    .shuffled(randomizer.random())*/
+
+        val singleCageAdjacentCounts =
+            singleCages.map { singleCage ->
+                grid.cages.count { grid.areAdjacent(singleCage, it) }
+            }.distinct().sorted()
+
+        val singleCagesOrdered =
+            singleCageAdjacentCounts.map {
+                singleCages.filter { singleCage -> grid.cages.count { grid.areAdjacent(singleCage, it) } == it }
+                    .shuffled(randomizer.random())
+            }.flatten()
+
+        singleCagesOrdered
+            .forEach { cage ->
+                cages.shuffled(randomizer.random()).forEach { otherCage ->
+                    if (cage != otherCage && grid.areAdjacent(cage, otherCage) && cage.cells.size + otherCage.cells.size <= 4) {
+                        val cellsToBeMerged = cage.cells + otherCage.cells
+
+                        val gridCageType = GridCageTypeLookup(grid, cellsToBeMerged).lookupType()
+
+                        if (gridCageType != null) {
+                            val newGrid =
+                                createNewGridByMergingTwoCages(grid, cage, otherCage, cellsToBeMerged, gridCageType)
+
+                            if (MathDokuDLXSolver().solve(newGrid) == 1) {
+                                return Pair(true, newGrid)
+                            }
+
+                            multiCageTries++
+                        }
+                    }
+                }
+            }
+
+        return Pair(false, grid)
+    }
+
+    private fun createNewGridByMergingTwoCages(
+        grid: Grid,
+        cage: GridCage,
+        otherCage: GridCage,
+        cageCells: List<GridCell>,
+        gridCageType: GridCageType? = null,
+    ): Grid {
+        val newGrid = Grid(variant)
+
+        val oldCages = grid.cages - cage - otherCage
+
+        var cageId = 0
+
+        oldCages.forEach {
+            val newCage =
+                GridCage.createWithCells(
+                    cageId,
+                    newGrid,
+                    it.action,
+                    newGrid.cells.first { newCell ->
+                        newCell.cellNumber == it.cells.first().cellNumber
+                    },
+                    it.cageType,
+                )
+            cageId++
+
+            newCage.result = it.result
+
+            newGrid.addCage(newCage)
+        }
+
+        grid.cells.forEachIndexed { index, gridCell ->
+            newGrid.cells[index].value = gridCell.value
+        }
+
+        val newCageCells = cageCells.map { oldCell -> newGrid.cells.first { it.cellNumber == oldCell.cellNumber } }
+
+        val operationDecider =
+            GridCageOperationDecider(
+                randomizer,
+                newCageCells,
+                variant.options.cageOperation,
+            )
+
+        val cageType =
+            if (newCageCells.size == 2) {
+                if (abs(newCageCells.first().cellNumber - newCageCells.last().cellNumber) == 1) {
+                    GridCageType.DOUBLE_HORIZONTAL
+                } else {
+                    GridCageType.DOUBLE_VERTICAL
+                }
+            } else {
+                gridCageType!!
+            }
+
+        val newCage =
+            GridCage.createWithCells(
+                cageId,
+                newGrid,
+                operationDecider.decideOperation(),
+                newCageCells.minBy { it.cellNumber },
+                cageType,
+            )
+
+        newGrid.addCage(newCage)
+
+        newCage.result = GridCageResultCalculator(newCage).calculateResultFromAction()
+
+        return newGrid
+    }
+
+    private fun createSingleCages(grid: Grid) {
+        var cageId = 0
+
+        grid.cells.forEach {
+            val cage = GridCage.createWithSingleCellArithmetic(cageId, grid, it)
+            cageId++
+
+            grid.addCage(cage)
+        }
+    }
+
+    private fun randomiseGrid(grid: Grid) {
+        val randomizer = GridRandomizer(shuffler, grid)
+        randomizer.createGrid()
+    }
+}

--- a/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/creation/RandomCageGridCalculator.kt
+++ b/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/creation/RandomCageGridCalculator.kt
@@ -14,8 +14,8 @@ class RandomCageGridCalculator(
     private val variant: GameVariant,
     private val randomizer: Randomizer = RandomSingleton.instance,
     private val shuffler: PossibleDigitsShuffler = RandomPossibleDigitsShuffler(),
-) {
-    suspend fun calculate(): Grid {
+) : GridCalculator {
+    override suspend fun calculate(): Grid {
         var dlxNumber: Int
         var numAttempts = 0
         var sumDLXDuration: Long = 0

--- a/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/creation/cage/GridCageTypeLookup.kt
+++ b/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/creation/cage/GridCageTypeLookup.kt
@@ -1,0 +1,26 @@
+package org.piepmeyer.gauguin.creation.cage
+
+import org.piepmeyer.gauguin.grid.Grid
+import org.piepmeyer.gauguin.grid.GridCell
+
+class GridCageTypeLookup(
+    private val grid: Grid,
+    private val cageCells: List<GridCell>,
+) {
+    fun lookupType(): GridCageType? {
+        val firstCell = cageCells.minBy { it.cellNumber }
+
+        return GridCageType.entries.filter { it.coordinates.size == cageCells.size }
+            .firstOrNull {
+                it.coordinates.all { coordinate ->
+                    val possibleCell =
+                        grid.getCellAt(
+                            firstCell.row + coordinate.second,
+                            firstCell.column + coordinate.first,
+                        )
+
+                    possibleCell != null && cageCells.contains(possibleCell)
+                }
+            }
+    }
+}

--- a/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/grid/Grid.kt
+++ b/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/grid/Grid.kt
@@ -142,6 +142,10 @@ class Grid(
         cages = cages + cage
     }
 
+    fun removeCage(cage: GridCage) {
+        cages = cages - cage
+    }
+
     fun clearUserValues() {
         for (cell in cells) {
             cell.clearUserValue()
@@ -255,5 +259,17 @@ class Grid(
             )
 
         return cellToTheEast?.cage == cage
+    }
+
+    fun areAdjacent(
+        firstCage: GridCage,
+        secondCage: GridCage,
+    ): Boolean {
+        return firstCage.cells.any { cell ->
+            getCage(cell.row + 1, cell.column) == secondCage ||
+                getCage(cell.row - 1, cell.column) == secondCage ||
+                getCage(cell.row, cell.column + 1) == secondCage ||
+                getCage(cell.row, cell.column - 1) == secondCage
+        }
     }
 }

--- a/gauguin-core/src/test/kotlin/org/piepmeyer/gauguin/creation/MergingCageGridCalculatorTest.kt
+++ b/gauguin-core/src/test/kotlin/org/piepmeyer/gauguin/creation/MergingCageGridCalculatorTest.kt
@@ -1,0 +1,31 @@
+package org.piepmeyer.gauguin.creation
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.kotest.core.spec.style.FunSpec
+import org.piepmeyer.gauguin.difficulty.GridDifficultyCalculator
+import org.piepmeyer.gauguin.grid.GridSize
+import org.piepmeyer.gauguin.options.GameOptionsVariant
+import org.piepmeyer.gauguin.options.GameVariant
+
+private val logger = KotlinLogging.logger {}
+
+class MergingCageGridCalculatorTest : FunSpec({
+
+    test("6x6 gets calculated") {
+
+        val randomizer = SeedRandomizerMock(1)
+
+        val calculator =
+            MergingCageGridCalculator(
+                variant = GameVariant(GridSize(6, 6), GameOptionsVariant.createClassic()),
+                randomizer = randomizer,
+                shuffler = RandomPossibleDigitsShuffler(randomizer.random),
+            )
+
+        val grid = calculator.calculate()
+
+        logger.info { grid }
+
+        logger.info { GridDifficultyCalculator(grid).calculate() }
+    }
+})


### PR DESCRIPTION
This new algorithm will hopefully replace the current one in the future. Currently, the new algorithm is available if:
  - The app runs in debug flavour and you choose "New Algorithm" when creating a new game.
  - You create a non-square grid.

The algorithm works by an initial grid with given, random numbers and single cell cages. It iterates merging two small cages into a larger one if the resulting grid still has one unique solution.

The new algorithm has a few advantages, e.g. it is guaranteed to find a valid grid with a unique solution. There a few glitches which have to be solved yet: There is no difficulty rating yet, it is not yet optimized performance wise and is likely to be slower at various square variants.