### PR TITLE
Avoid calling setFontVariationSettings twice pre-Q

### DIFF
--- a/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/grid/GridFontHolder.kt
+++ b/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/grid/GridFontHolder.kt
@@ -13,11 +13,21 @@ class GridFontHolder(
     val fontValue: Typeface
 
     init {
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
             val builder = Typeface.Builder(context.assets, "font/InterVariable.ttf")
 
             fontPossibles = builder.setFontVariationSettings("'wght' 400").build()
             fontValue = builder.setFontVariationSettings("'wght' 425").build()
+            fontCageText = builder.setFontVariationSettings("'wght' 575").build()
+        } else if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+            // Builders can't be reused in SDKs O and P
+            var builder = Typeface.Builder(context.assets, "font/InterVariable.ttf")
+            fontPossibles = builder.setFontVariationSettings("'wght' 400").build()
+
+            builder = Typeface.Builder(context.assets, "font/InterVariable.ttf")
+            fontValue = builder.setFontVariationSettings("'wght' 425").build()
+
+            builder = Typeface.Builder(context.assets, "font/InterVariable.ttf")
             fontCageText = builder.setFontVariationSettings("'wght' 575").build()
         } else {
             fontPossibles = checkNotNull(ResourcesCompat.getFont(context, R.font.inter_regular))


### PR DESCRIPTION
In Android SDKs O and P, setFontVariationSettings can only be called once; it throws an exception on subsequent invocations. This fixes that by using a new builder for every font construction in pre-Q environments.

Fixes: #232