### PR TITLE
Include undo steps when saving grids.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The undo steps a a grid are included when it gets saved. This means that the undo steps get lost
+  no longer it the grid gets loaded, including autosaved grids.
+
 ### Changed
 
-- Show the game solved dialog if the grid shown at the start of the app has alredy been solved. 
+- Show the game solved dialog if the grid shown at the start of the app has already been solved.
+- Build against Android 15 (that is SDK 35). Proper edge to edge support has still to come.
 
 ### Deprecated
 

--- a/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/main/MainBottomAppBarService.kt
+++ b/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/main/MainBottomAppBarService.kt
@@ -8,8 +8,6 @@ import org.koin.core.component.inject
 import org.piepmeyer.gauguin.R
 import org.piepmeyer.gauguin.databinding.ActivityMainBinding
 import org.piepmeyer.gauguin.game.Game
-import org.piepmeyer.gauguin.undo.UndoListener
-import org.piepmeyer.gauguin.undo.UndoManager
 
 class MainBottomAppBarService(
     private val mainActivity: MainActivity,
@@ -37,10 +35,9 @@ class MainBottomAppBarService(
             }
         }
 
-        val undoListener = UndoListener { undoPossible -> undoButton.isEnabled = undoPossible }
-        val undoList = UndoManager(undoListener)
-
-        game.undoManager = undoList
+        game.undoManager.addListener { undoPossible ->
+            undoButton.isEnabled = undoPossible
+        }
 
         binding.hint.setOnClickListener { mainActivity.checkProgress() }
         undoButton.setOnClickListener { game.undoOneStep() }
@@ -66,9 +63,7 @@ class MainBottomAppBarService(
             binding.hint.show()
 
             undoButton.visibility = View.VISIBLE
-            undoButton.isEnabled = false
-
-            eraserButton?.visibility = View.VISIBLE
+            undoButton.isEnabled = game.undoManager.undoPossible()
 
             solveHelperMenuItems().forEach { it.setVisible(true) }
         }

--- a/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/CoreModule.kt
+++ b/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/CoreModule.kt
@@ -18,7 +18,6 @@ import org.piepmeyer.gauguin.options.GameOptionsVariant
 import org.piepmeyer.gauguin.options.GameVariant
 import org.piepmeyer.gauguin.preferences.ApplicationPreferences
 import org.piepmeyer.gauguin.preferences.StatisticsManager
-import org.piepmeyer.gauguin.undo.UndoManager
 import java.io.File
 
 class CoreModule(
@@ -31,7 +30,6 @@ class CoreModule(
 
                 Game(
                     grid,
-                    UndoManager { },
                     initialGridView(grid),
                     get(StatisticsManager::class),
                     get(ApplicationPreferences::class),
@@ -80,15 +78,14 @@ class CoreModule(
         }
     }
 
-    private fun initialGameVariant(): GameVariant {
-        return GameVariant(
+    private fun initialGameVariant(): GameVariant =
+        GameVariant(
             GridSize(6, 6),
             GameOptionsVariant.createClassic(),
         )
-    }
 
-    private fun initialGridView(grid: Grid): GridView {
-        return object : GridView {
+    private fun initialGridView(grid: Grid): GridView =
+        object : GridView {
             override var grid: Grid
                 get() = grid
                 set(_) {
@@ -101,5 +98,4 @@ class CoreModule(
                 // dummy implementation
             }
         }
-    }
 }

--- a/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/game/Game.kt
+++ b/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/game/Game.kt
@@ -9,12 +9,12 @@ import org.piepmeyer.gauguin.grid.GridView
 import org.piepmeyer.gauguin.preferences.ApplicationPreferences
 import org.piepmeyer.gauguin.preferences.StatisticsManager
 import org.piepmeyer.gauguin.undo.UndoManager
+import org.piepmeyer.gauguin.undo.UndoManagerImpl
 
 private val logger = KotlinLogging.logger {}
 
 data class Game(
     val initalGrid: Grid,
-    var undoManager: UndoManager,
     var gridUI: GridView,
     @InjectedParam private val statisticsManager: StatisticsManager,
     @InjectedParam private val applicationPreferences: ApplicationPreferences,
@@ -29,6 +29,8 @@ data class Game(
 
     var grid: Grid = initalGrid
         private set
+
+    val undoManager: UndoManager = UndoManagerImpl { grid }
 
     fun enterFastFinishingMode() {
         gameMode = FastFinishingGameMode(this)

--- a/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/game/save/SavedGrid.kt
+++ b/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/game/save/SavedGrid.kt
@@ -8,6 +8,7 @@ import kotlin.time.Duration.Companion.milliseconds
 
 @Serializable
 data class SavedGrid(
+    val version: Int = 1,
     val variant: GameVariant,
     val savedAtInMilliseconds: Long,
     val playTimeInMilliseconds: Long,
@@ -19,6 +20,7 @@ data class SavedGrid(
     val invalidCellNumbers: List<Int>,
     val cheatedCellNumbers: List<Int>,
     val cages: List<SavedCage>,
+    val undoSteps: List<SavedUndoStep> = emptyList(),
 ) {
     fun toGrid(): Grid {
         val grid = Grid(variant, savedAtInMilliseconds)
@@ -58,6 +60,8 @@ data class SavedGrid(
                 cage
             }
 
+        grid.undoSteps.addAll(undoSteps.map { it.toUndoStep(grid) })
+
         return grid
     }
 
@@ -70,6 +74,10 @@ data class SavedGrid(
             val savedCages =
                 grid.cages.map {
                     SavedCage.fromCage(it)
+                }
+            val savedUndoSteps =
+                grid.undoSteps.map {
+                    SavedUndoStep.fromUndoStep(it)
                 }
 
             return SavedGrid(
@@ -84,6 +92,7 @@ data class SavedGrid(
                 invalidCellNumbers = grid.invalidsHighlighted().map { it.cellNumber },
                 cheatedCellNumbers = grid.cheatedHighlighted().map { it.cellNumber },
                 cages = savedCages,
+                undoSteps = savedUndoSteps,
             )
         }
     }

--- a/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/game/save/SavedUndoStep.kt
+++ b/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/game/save/SavedUndoStep.kt
@@ -1,0 +1,31 @@
+package org.piepmeyer.gauguin.game.save
+
+import kotlinx.serialization.Serializable
+import org.piepmeyer.gauguin.grid.Grid
+import org.piepmeyer.gauguin.undo.UndoStep
+
+@Serializable
+data class SavedUndoStep(
+    val cellNumber: Int,
+    val userValue: Int,
+    val possibles: Set<Int>,
+    val isBatch: Boolean,
+) {
+    fun toUndoStep(grid: Grid) =
+        UndoStep(
+            cell = grid.cells[cellNumber],
+            userValue = userValue,
+            possibles = possibles,
+            isBatch = isBatch,
+        )
+
+    companion object {
+        fun fromUndoStep(undoStep: UndoStep) =
+            SavedUndoStep(
+                cellNumber = undoStep.cell.cellNumber,
+                userValue = undoStep.userValue,
+                possibles = undoStep.possibles,
+                isBatch = undoStep.isBatch,
+            )
+    }
+}

--- a/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/grid/Grid.kt
+++ b/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/grid/Grid.kt
@@ -3,6 +3,7 @@ package org.piepmeyer.gauguin.grid
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.piepmeyer.gauguin.options.GameOptionsVariant
 import org.piepmeyer.gauguin.options.GameVariant
+import org.piepmeyer.gauguin.undo.UndoStep
 import kotlin.time.Duration
 
 private val logger = KotlinLogging.logger {}
@@ -23,6 +24,8 @@ class Grid(
     var isActive = false
     var creationDate: Long = 0
         private set
+
+    val undoSteps = mutableListOf<UndoStep>()
 
     constructor(variant: GameVariant, creationDate: Long) : this(variant) {
         this.creationDate = creationDate

--- a/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/undo/UndoManager.kt
+++ b/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/undo/UndoManager.kt
@@ -2,41 +2,17 @@ package org.piepmeyer.gauguin.undo
 
 import org.piepmeyer.gauguin.grid.GridCell
 
-class UndoManager(private val listener: UndoListener) {
-    private val undoList = mutableListOf<UndoState>()
+interface UndoManager {
+    fun addListener(listener: UndoListener)
 
-    fun clear() {
-        undoList.clear()
-    }
+    fun clear()
 
     fun saveUndo(
         cell: GridCell,
         batch: Boolean,
-    ) {
-        val undoState =
-            UndoState(
-                cell,
-                cell.userValue,
-                cell.possibles,
-                batch,
-            )
-        undoList.add(undoState)
-        listener.undoStateChanged(true)
-    }
+    )
 
-    fun restoreUndo() {
-        if (undoList.isNotEmpty()) {
-            val undoState = undoList.removeLast()
-            val cell = undoState.cell
-            cell.setUserValueIntern(undoState.userValue)
-            cell.possibles = undoState.possibles
-            cell.isLastModified = true
-            if (undoState.isBatch) {
-                restoreUndo()
-            }
-        }
-        if (undoList.isEmpty()) {
-            listener.undoStateChanged(false)
-        }
-    }
+    fun restoreUndo()
+
+    fun undoPossible(): Boolean
 }

--- a/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/undo/UndoManagerImpl.kt
+++ b/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/undo/UndoManagerImpl.kt
@@ -1,0 +1,54 @@
+package org.piepmeyer.gauguin.undo
+
+import org.piepmeyer.gauguin.grid.Grid
+import org.piepmeyer.gauguin.grid.GridCell
+
+class UndoManagerImpl(
+    private val gridHolder: () -> Grid,
+) : UndoManager {
+    private val listeners = mutableListOf<UndoListener>()
+
+    private fun undoSteps() = gridHolder.invoke().undoSteps
+
+    override fun addListener(listener: UndoListener) {
+        listeners += listener
+    }
+
+    override fun clear() {
+        undoSteps().clear()
+    }
+
+    override fun saveUndo(
+        cell: GridCell,
+        batch: Boolean,
+    ) {
+        val undoStep =
+            UndoStep(
+                cell,
+                cell.userValue,
+                cell.possibles,
+                batch,
+            )
+        undoSteps().add(undoStep)
+
+        listeners.forEach { it.undoStateChanged(true) }
+    }
+
+    override fun restoreUndo() {
+        if (undoSteps().isNotEmpty()) {
+            val undoState = undoSteps().removeAt(undoSteps().lastIndex)
+            val cell = undoState.cell
+            cell.setUserValueIntern(undoState.userValue)
+            cell.possibles = undoState.possibles
+            cell.isLastModified = true
+            if (undoState.isBatch) {
+                restoreUndo()
+            }
+        }
+        if (undoSteps().isEmpty()) {
+            listeners.forEach { it.undoStateChanged(false) }
+        }
+    }
+
+    override fun undoPossible() = undoSteps().isNotEmpty()
+}

--- a/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/undo/UndoStep.kt
+++ b/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/undo/UndoStep.kt
@@ -2,7 +2,7 @@ package org.piepmeyer.gauguin.undo
 
 import org.piepmeyer.gauguin.grid.GridCell
 
-data class UndoState(
+data class UndoStep(
     val cell: GridCell,
     val userValue: Int,
     val possibles: Set<Int>,

--- a/gauguin-core/src/test/kotlin/org/piepmeyer/gauguin/game/GameTest.kt
+++ b/gauguin-core/src/test/kotlin/org/piepmeyer/gauguin/game/GameTest.kt
@@ -16,166 +16,164 @@ import org.piepmeyer.gauguin.grid.GridCell
 import org.piepmeyer.gauguin.preferences.ApplicationPreferences
 import org.piepmeyer.gauguin.preferences.StatisticsManager
 
-class GameTest : FunSpec(
-    {
-        test("restart game clears all values and all possible values") {
-            val preferences =
-                mockk<ApplicationPreferences> {
-                    every { showDupedDigits() } returns true
-                }
+class GameTest :
+    FunSpec(
+        {
+            test("restart game clears all values and all possible values") {
+                val preferences =
+                    mockk<ApplicationPreferences> {
+                        every { showDupedDigits() } returns true
+                    }
 
-            val game = gameWithSmallGrid(preferences)
+                val game = gameWithSmallGrid(preferences)
 
-            game.restartGame()
+                game.restartGame()
 
-            game.grid.cells.forEach { it.userValue shouldBe GridCell.NO_VALUE_SET }
-            game.grid.cells.forEach { it.possibles.shouldBeEmpty() }
+                game.grid.cells.forEach { it.userValue shouldBe GridCell.NO_VALUE_SET }
+                game.grid.cells.forEach { it.possibles.shouldBeEmpty() }
 
-            stopKoin()
-        }
+                stopKoin()
+            }
 
-        test("restart game clears last modified flags of all cells") {
-            startKoin { }
+            test("restart game clears last modified flags of all cells") {
+                startKoin { }
 
-            val preferences =
-                mockk<ApplicationPreferences> {
-                    every { showDupedDigits() } returns true
-                }
+                val preferences =
+                    mockk<ApplicationPreferences> {
+                        every { showDupedDigits() } returns true
+                    }
 
-            val game = gameWithSmallGrid(preferences)
+                val game = gameWithSmallGrid(preferences)
 
-            game.restartGame()
+                game.restartGame()
 
-            game.grid.cells.forEach { it.isLastModified shouldBe false }
-        }
+                game.grid.cells.forEach { it.isLastModified shouldBe false }
+            }
 
-        test("revealing a cell sets the correct user value and clears possible numbers") {
-            val preferences =
-                mockk<ApplicationPreferences> {
-                    every { showDupedDigits() } returns true
-                    every { removePencils() } returns true
-                }
-            val statisticsManager =
-                mockk<StatisticsManager> {
-                    every { puzzleStartedToBePlayed() } just runs
-                    every { storeStreak(false) } just runs
-                }
+            test("revealing a cell sets the correct user value and clears possible numbers") {
+                val preferences =
+                    mockk<ApplicationPreferences> {
+                        every { showDupedDigits() } returns true
+                        every { removePencils() } returns true
+                    }
+                val statisticsManager =
+                    mockk<StatisticsManager> {
+                        every { puzzleStartedToBePlayed() } just runs
+                        every { storeStreak(false) } just runs
+                    }
 
-            val smallGrid =
-                GridBuilder(2)
-                    .addCage(2, GridCageAction.ACTION_MULTIPLY, GridCageType.ANGLE_RIGHT_BOTTOM, 0)
-                    .addSingleCage(2, 3)
-                    .createGrid()
-            smallGrid.isActive = true
+                val smallGrid =
+                    GridBuilder(2)
+                        .addCage(2, GridCageAction.ACTION_MULTIPLY, GridCageType.ANGLE_RIGHT_BOTTOM, 0)
+                        .addSingleCage(2, 3)
+                        .createGrid()
+                smallGrid.isActive = true
 
-            val cellToReveal = smallGrid.cells[0]
+                val cellToReveal = smallGrid.cells[0]
 
-            cellToReveal.addPossible(1)
-            cellToReveal.addPossible(2)
-            cellToReveal.value = 2
-            cellToReveal.userValue = 1
-            smallGrid.selectedCell = cellToReveal
+                cellToReveal.addPossible(1)
+                cellToReveal.addPossible(2)
+                cellToReveal.value = 2
+                cellToReveal.userValue = 1
+                smallGrid.selectedCell = cellToReveal
 
-            val game =
-                Game(
-                    initalGrid = smallGrid,
-                    mockk(relaxed = true),
-                    mockk(relaxed = true),
-                    statisticsManager,
-                    preferences,
-                )
+                val game =
+                    Game(
+                        initalGrid = smallGrid,
+                        mockk(relaxed = true),
+                        statisticsManager,
+                        preferences,
+                    )
 
-            game.revealCell(cellToReveal)
+                game.revealCell(cellToReveal)
 
-            cellToReveal.possibles.shouldBeEmpty()
-            cellToReveal.userValue shouldBe 2
-        }
+                cellToReveal.possibles.shouldBeEmpty()
+                cellToReveal.userValue shouldBe 2
+            }
 
-        test("fillSingleCagesInNewGrid fills userValues of single cages") {
-            val preferences =
-                mockk<ApplicationPreferences> {
-                    every { removePencils() } returns false
-                }
+            test("fillSingleCagesInNewGrid fills userValues of single cages") {
+                val preferences =
+                    mockk<ApplicationPreferences> {
+                        every { removePencils() } returns false
+                    }
 
-            val grid =
-                GridBuilder(3)
-                    .addCage(1, GridCageAction.ACTION_MULTIPLY, GridCageType.TRIPLE_HORIZONTAL, 0)
-                    .addSingleCage(2, 3)
-                    .addSingleCage(3, 4)
-                    .addSingleCage(4, 5)
-                    .addCage(1, GridCageAction.ACTION_MULTIPLY, GridCageType.TRIPLE_HORIZONTAL, 6)
-                    .createGrid()
+                val grid =
+                    GridBuilder(3)
+                        .addCage(1, GridCageAction.ACTION_MULTIPLY, GridCageType.TRIPLE_HORIZONTAL, 0)
+                        .addSingleCage(2, 3)
+                        .addSingleCage(3, 4)
+                        .addSingleCage(4, 5)
+                        .addCage(1, GridCageAction.ACTION_MULTIPLY, GridCageType.TRIPLE_HORIZONTAL, 6)
+                        .createGrid()
 
-            grid.getCell(3).value = 2
-            grid.getCell(4).value = 3
-            grid.getCell(5).value = 4
+                grid.getCell(3).value = 2
+                grid.getCell(4).value = 3
+                grid.getCell(5).value = 4
 
-            val game =
-                Game(
-                    initalGrid = grid,
-                    mockk(relaxed = true),
-                    mockk(relaxed = true),
-                    mockk(relaxed = true),
-                    preferences,
-                )
+                val game =
+                    Game(
+                        initalGrid = grid,
+                        mockk(relaxed = true),
+                        mockk(relaxed = true),
+                        preferences,
+                    )
 
-            game.fillSingleCagesInNewGrid()
+                game.fillSingleCagesInNewGrid()
 
-            grid.getCell(0).userValue shouldBe GridCell.NO_VALUE_SET
-            grid.getCell(1).userValue shouldBe GridCell.NO_VALUE_SET
-            grid.getCell(2).userValue shouldBe GridCell.NO_VALUE_SET
-            grid.getCell(3).userValue shouldBe 2
-            grid.getCell(4).userValue shouldBe 3
-            grid.getCell(5).userValue shouldBe 4
-            grid.getCell(6).userValue shouldBe GridCell.NO_VALUE_SET
-            grid.getCell(7).userValue shouldBe GridCell.NO_VALUE_SET
-            grid.getCell(8).userValue shouldBe GridCell.NO_VALUE_SET
-        }
+                grid.getCell(0).userValue shouldBe GridCell.NO_VALUE_SET
+                grid.getCell(1).userValue shouldBe GridCell.NO_VALUE_SET
+                grid.getCell(2).userValue shouldBe GridCell.NO_VALUE_SET
+                grid.getCell(3).userValue shouldBe 2
+                grid.getCell(4).userValue shouldBe 3
+                grid.getCell(5).userValue shouldBe 4
+                grid.getCell(6).userValue shouldBe GridCell.NO_VALUE_SET
+                grid.getCell(7).userValue shouldBe GridCell.NO_VALUE_SET
+                grid.getCell(8).userValue shouldBe GridCell.NO_VALUE_SET
+            }
 
-        test("fillSingleCagesInNewGrid with remove pencils deletes pencils marks") {
-            val preferences =
-                mockk<ApplicationPreferences> {
-                    every { removePencils() } returns true
-                }
+            test("fillSingleCagesInNewGrid with remove pencils deletes pencils marks") {
+                val preferences =
+                    mockk<ApplicationPreferences> {
+                        every { removePencils() } returns true
+                    }
 
-            val grid =
-                GridBuilder(3)
-                    .addCage(1, GridCageAction.ACTION_MULTIPLY, GridCageType.TRIPLE_HORIZONTAL, 0)
-                    .addSingleCage(2, 3)
-                    .addSingleCage(3, 4)
-                    .addSingleCage(4, 5)
-                    .addCage(1, GridCageAction.ACTION_MULTIPLY, GridCageType.TRIPLE_HORIZONTAL, 6)
-                    .createGrid()
+                val grid =
+                    GridBuilder(3)
+                        .addCage(1, GridCageAction.ACTION_MULTIPLY, GridCageType.TRIPLE_HORIZONTAL, 0)
+                        .addSingleCage(2, 3)
+                        .addSingleCage(3, 4)
+                        .addSingleCage(4, 5)
+                        .addCage(1, GridCageAction.ACTION_MULTIPLY, GridCageType.TRIPLE_HORIZONTAL, 6)
+                        .createGrid()
 
-            grid.addPossiblesAtNewGame()
+                grid.addPossiblesAtNewGame()
 
-            grid.getCell(3).value = 1
-            grid.getCell(4).value = 2
-            grid.getCell(5).value = 3
+                grid.getCell(3).value = 1
+                grid.getCell(4).value = 2
+                grid.getCell(5).value = 3
 
-            val game =
-                Game(
-                    initalGrid = grid,
-                    mockk(relaxed = true),
-                    mockk(relaxed = true),
-                    mockk(relaxed = true),
-                    preferences,
-                )
+                val game =
+                    Game(
+                        initalGrid = grid,
+                        mockk(relaxed = true),
+                        mockk(relaxed = true),
+                        preferences,
+                    )
 
-            game.fillSingleCagesInNewGrid()
+                game.fillSingleCagesInNewGrid()
 
-            grid.getCell(0).possibles shouldBe setOf(2, 3)
-            grid.getCell(1).possibles shouldBe setOf(1, 3)
-            grid.getCell(2).possibles shouldBe setOf(1, 2)
-            grid.getCell(3).possibles shouldBe emptySet()
-            grid.getCell(4).possibles shouldBe emptySet()
-            grid.getCell(5).possibles shouldBe emptySet()
-            grid.getCell(6).possibles shouldBe setOf(2, 3)
-            grid.getCell(7).possibles shouldBe setOf(1, 3)
-            grid.getCell(8).possibles shouldBe setOf(1, 2)
-        }
-    },
-)
+                grid.getCell(0).possibles shouldBe setOf(2, 3)
+                grid.getCell(1).possibles shouldBe setOf(1, 3)
+                grid.getCell(2).possibles shouldBe setOf(1, 2)
+                grid.getCell(3).possibles shouldBe emptySet()
+                grid.getCell(4).possibles shouldBe emptySet()
+                grid.getCell(5).possibles shouldBe emptySet()
+                grid.getCell(6).possibles shouldBe setOf(2, 3)
+                grid.getCell(7).possibles shouldBe setOf(1, 3)
+                grid.getCell(8).possibles shouldBe setOf(1, 2)
+            }
+        },
+    )
 
 private fun gameWithSmallGrid(preferences: ApplicationPreferences): Game {
     val smallGrid =
@@ -190,7 +188,6 @@ private fun gameWithSmallGrid(preferences: ApplicationPreferences): Game {
 
     return Game(
         initalGrid = smallGrid,
-        undoManager = mockk(relaxed = true),
         gridUI = mockk(relaxed = true),
         statisticsManager = mockk(relaxed = true),
         applicationPreferences = preferences,


### PR DESCRIPTION
Solves missing undo history if the grid got reloaded after loading an autosaved grid.