### PR TITLE
add first version of new statistics implementation

### DIFF
--- a/docs/statistics-requirements.md
+++ b/docs/statistics-requirements.md
@@ -1,0 +1,47 @@
+# Features and requirements of statistics
+
+The new implementation should remember all games played and calculate the relevant numbers for
+statistics and best time on demand.
+
+This should enable to add more statistics in the future using the then existing history.
+This will work if the new statistics do not need new data, but use the given structure to obtain
+them.
+
+The new statistics will live next to the existing one, to avoid every user loosing their history.
+The idea of the migration is
+
+1. Gather both statistics in parallel to avoid abruptly losing the statistics
+2. Optimize new statistics and gather more history
+3. Delete the old statistics after a relevant time
+
+## Ideas from the past
+
+* Avoid showing only the last 50 games via diagrams.
+* Let the user choose which grid variants to show (e.g. "all", "9x9",...)
+* Tapping on a diagram will show it full screen.
+* Keep Best Times for each grid variant (if feasible)
+* Display "total time spend"
+* Which games were solved with help and without?
+* List the easiest and hardest games ever solved
+
+## Feature list
+
+* Filter by
+  * grid size (done)
+  * other game variant (e.g. only multiplication, including zero etc.)
+  * time, e.g. "games last week"
+* "Comparable grids"
+  * should compare only similar grid constellations so that the user gets data related to similar
+    grids
+  * Can a camparison done by comparing the difficulty rating of the grid variant?
+
+## Remaining problems
+
+## Best Time
+
+Currently, the best time is stored by the size of the grid, e.g. 6x6.
+
+* Different variants or difficulty levels may require their own best time.
+* The best time should be understandable.
+
+Its unclear which way to go.

--- a/gauguin-app/src/main/AndroidManifest.xml
+++ b/gauguin-app/src/main/AndroidManifest.xml
@@ -25,9 +25,8 @@
         <activity android:name=".ui.newgame.NewGameActivity" />
         <activity android:name=".ui.challenge.ChooseChallengeActivity" />
         <activity android:name=".ui.LoadGameListActivity" />
-        <activity
-            android:name=".ui.statistics.legacy.LegacyStatisticsActivity"
-            android:label="@string/statistics_title" />
+        <activity android:name=".ui.statistics.StatisticsActivity" />
+        <activity android:name=".ui.statistics.legacy.LegacyStatisticsActivity" />
         <activity android:name=".ui.statistics.legacy.LegacyStatisticsMaximizeOneDiagramActivity" />
         <activity android:name=".ui.AboutActivity" />
         <activity

--- a/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/AppModule.kt
+++ b/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/AppModule.kt
@@ -16,6 +16,7 @@ import org.piepmeyer.gauguin.preferences.StatisticsManagerWriting
 import org.piepmeyer.gauguin.ui.ActivityUtils
 import org.piepmeyer.gauguin.ui.main.MainViewModel
 import org.piepmeyer.gauguin.ui.newgame.NewGameViewModel
+import org.piepmeyer.gauguin.ui.statistics.StatisticsViewModel
 
 class AppModule(
     private val applicationPreferences: ApplicationPreferencesImpl,
@@ -41,5 +42,6 @@ class AppModule(
             single { ActivityUtils() }
             single { MainViewModel(applicationScope) }
             viewModel { NewGameViewModel(get(), get(), get()) }
+            viewModel { StatisticsViewModel(get()) }
         }
 }

--- a/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/preferences/StatisticsManagerImpl.kt
+++ b/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/preferences/StatisticsManagerImpl.kt
@@ -6,8 +6,11 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
 import kotlinx.serialization.json.encodeToStream
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 import org.piepmeyer.gauguin.difficulty.ensureDifficultyCalculated
 import org.piepmeyer.gauguin.grid.Grid
+import org.piepmeyer.gauguin.history.HistoryService
 import org.piepmeyer.gauguin.statistics.Statistics
 import java.io.File
 import java.io.IOException
@@ -21,7 +24,10 @@ class StatisticsManagerImpl(
     directory: File,
     sharedPreferences: SharedPreferences,
 ) : StatisticsManagerWriting,
-    StatisticsManagerReading {
+    StatisticsManagerReading,
+    KoinComponent {
+    private val historyService: HistoryService by inject()
+
     private val numberOfItemsOfStore = 50
     private val statisticsFile = File(directory, "statistics.yaml")
     private val legacyManager = LegacyStatisticsManager(sharedPreferences)
@@ -34,6 +40,8 @@ class StatisticsManagerImpl(
     }
 
     override fun puzzleSolved(grid: Grid) {
+        historyService.gridHasBeenSolved(grid)
+
         statistics.overall.gamesSolved++
 
         if (grid.isCheated()) {
@@ -92,6 +100,8 @@ class StatisticsManagerImpl(
 
     override fun endCurrentGame(grid: Grid) {
         if (grid.isActive && !grid.isSolved() && grid.startedToBePlayed) {
+            historyService.gridHasBeenEndedUnsolved(grid)
+
             storeStreak(false)
         }
     }

--- a/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/statistics/StatisticsActivity.kt
+++ b/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/statistics/StatisticsActivity.kt
@@ -1,0 +1,186 @@
+package org.piepmeyer.gauguin.ui.statistics
+
+import android.content.DialogInterface
+import android.os.Bundle
+import android.view.View
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.fragment.app.commit
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.google.android.material.chip.Chip
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import kotlinx.coroutines.launch
+import org.koin.android.ext.android.inject
+import org.koin.androidx.viewmodel.ext.android.viewModel
+import org.piepmeyer.gauguin.R
+import org.piepmeyer.gauguin.databinding.ActivityStatisticsBinding
+import org.piepmeyer.gauguin.history.History
+import org.piepmeyer.gauguin.history.HistoryView
+import org.piepmeyer.gauguin.preferences.StatisticsManagerReading
+import org.piepmeyer.gauguin.ui.ActivityUtils
+import org.piepmeyer.gauguin.ui.grid.displayableName
+
+class StatisticsActivity : AppCompatActivity() {
+    private val activityUtils: ActivityUtils by inject()
+    private val statisticsManager: StatisticsManagerReading by inject()
+    private val viewModel: StatisticsViewModel by viewModel()
+
+    private lateinit var binding: ActivityStatisticsBinding
+
+    private lateinit var scatterPlotDiagramFragment: StatisticsScatterPlotDiagramFragment
+    private lateinit var difficultyDiagramFragment: StatisticsDifficultyDiagramFragment
+    private lateinit var durationDiagramFragment: StatisticsDurationDiagramFragment
+    private lateinit var streaksDiagramFragment: StatisticsStreaksDiagramFragment
+    private var multiDiagramFragment: StatisticsMultiDiagramFragment? = null
+
+    private var gridSizeChipsHaveBeenCreated: Boolean = false
+
+    public override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        activityUtils.configureTheme(this)
+        binding = ActivityStatisticsBinding.inflate(layoutInflater)
+        enableEdgeToEdge()
+        setContentView(binding.root)
+        activityUtils.configureMainContainerBackground(binding.root)
+        activityUtils.configureRootView(binding.root)
+
+        binding.statisticsClose.setOnClickListener {
+            finishAfterTransition()
+        }
+
+        binding.clearstats.setOnClickListener { _: View? ->
+            resetStatisticsDialog()
+        }
+
+        activityUtils.configureFullscreen(this)
+
+        binding.chipSizesAll.setOnClickListener {
+            viewModel.viewAllSizes()
+        }
+
+        scatterPlotDiagramFragment = StatisticsScatterPlotDiagramFragment()
+        difficultyDiagramFragment = StatisticsDifficultyDiagramFragment()
+        durationDiagramFragment = StatisticsDurationDiagramFragment()
+        streaksDiagramFragment = StatisticsStreaksDiagramFragment()
+
+        supportFragmentManager.commit {
+            if (binding.multiDiagramFrame != null) {
+                val fragment =
+                    StatisticsMultiDiagramFragment(
+                        scatterPlotDiagramFragment,
+                        durationDiagramFragment,
+                    )
+
+                multiDiagramFragment = fragment
+                replace(binding.multiDiagramFrame!!.id, fragment)
+            }
+            /*else {
+                binding.scatterPlotCardView?.let { replace(it.id, scatterPlotDiagramFragment) }
+                binding.overallDurationCardView?.let { replace(it.id, durationDiagramFragment) }
+            }*/
+
+            replace(binding.overallDifficultyCardView.id, difficultyDiagramFragment)
+            replace(binding.overallStreaksCardView.id, streaksDiagramFragment)
+        }
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.historyState.collect {
+                    when (it) {
+                        is HistoryState.HistoryEmpty -> {
+                            binding.noStatisticsAvailableYetCardView.visibility = View.VISIBLE
+                            binding.longeststreak.text = "0"
+                            binding.solvedstreak.text = "0"
+                            binding.startedstat.text = "0"
+                            binding.solvedstat.text = "0"
+                        }
+
+                        is HistoryState.HistoryLoaded -> {
+                            binding.noStatisticsAvailableYetCardView.visibility = View.GONE
+                            createSizeChips(it.history)
+                            updateHistoryView(it.view)
+                        }
+
+                        is HistoryState.HistoryLoading -> {
+                            binding.noStatisticsAvailableYetCardView.visibility = View.GONE
+                        }
+                    }
+                }
+            }
+        }
+
+        ViewCompat.setOnApplyWindowInsetsListener(
+            binding.root,
+        ) { v, insets ->
+            val innerPadding =
+                insets.getInsets(
+                    WindowInsetsCompat.Type.systemBars()
+                        or WindowInsetsCompat.Type.displayCutout(),
+                )
+            v.setPadding(
+                0,
+                0,
+                0,
+                innerPadding.bottom,
+            )
+
+            WindowInsetsCompat.CONSUMED
+        }
+    }
+
+    private fun createSizeChips(history: History) {
+        if (gridSizeChipsHaveBeenCreated) {
+            return
+        }
+
+        gridSizeChipsHaveBeenCreated = true
+
+        history.gridSizes().sortedBy { it.width }.forEach { gridSize ->
+            val chip =
+                Chip(
+                    binding.sizesChipGroup.context,
+                    null,
+                    com.google.android.material.R.style.Widget_Material3_Chip_Filter,
+                )
+
+            chip.id = View.generateViewId()
+            chip.text = gridSize.displayableName(binding.sizesChipGroup.context)
+            chip.isCheckable = true
+            chip.isClickable = true
+            // chip.setTextAppearance(binding.sizesChipGroup.context, com.google.android.material.R.style.Widget_Material3_Chip_Filter)
+
+            binding.sizesChipGroup.addView(chip)
+
+            chip.setOnClickListener {
+                viewModel.viewOnlyOneGridSize(gridSize)
+            }
+        }
+    }
+
+    private fun updateHistoryView(view: HistoryView) {
+        binding.longeststreak.text = view.longestStreak().toString()
+        binding.solvedstreak.text = view.currentStreak().toString()
+        binding.startedstat.text = view.playedGrids().toString()
+        binding.solvedstat.text = view.numberOfSolvedGrids().toString()
+    }
+
+    private fun resetStatisticsDialog() {
+        MaterialAlertDialogBuilder(this)
+            .setTitle(R.string.statistics_dialog_reset_statistics_title)
+            .setMessage(R.string.statistics_dialog_reset_statistics_message)
+            .setNegativeButton(
+                R.string.statistics_dialog_reset_statistics_cancel_button,
+            ) { dialog: DialogInterface, _: Int -> dialog.cancel() }
+            .setPositiveButton(R.string.statistics_dialog_reset_statistics_ok_button) { _: DialogInterface?, _: Int ->
+                run {
+                    statisticsManager.clearStatistics()
+                    // updateViews()
+                }
+            }.show()
+    }
+}

--- a/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/statistics/StatisticsDifficultyDiagramFragment.kt
+++ b/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/statistics/StatisticsDifficultyDiagramFragment.kt
@@ -1,0 +1,77 @@
+package org.piepmeyer.gauguin.ui.statistics
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.allViews
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.launch
+import org.koin.androidx.viewmodel.ext.android.activityViewModel
+import org.koin.core.component.KoinComponent
+import org.piepmeyer.gauguin.R
+import org.piepmeyer.gauguin.databinding.FragmentStatisticsDifficultyDiagramBinding
+import org.piepmeyer.gauguin.history.HistoryView
+import org.piepmeyer.gauguin.ui.statistics.legacy.LegacyStatisticsActivity
+import kotlin.math.roundToInt
+
+class StatisticsDifficultyDiagramFragment :
+    Fragment(R.layout.fragment_statistics_difficulty_diagram),
+    FragmentWithClickListenerForAllViews,
+    KoinComponent {
+    lateinit var binding: FragmentStatisticsDifficultyDiagramBinding
+    override var clickListenerForAllViews: View.OnClickListener? = null
+
+    private val viewModel: StatisticsViewModel by activityViewModel()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        parent: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        binding = FragmentStatisticsDifficultyDiagramBinding.inflate(inflater, parent, false)
+
+        lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.historyState.collect {
+                    when (it) {
+                        is HistoryState.HistoryLoaded -> {
+                            updateHistoryView(it.view)
+                            binding.root.visibility = View.VISIBLE
+                        }
+
+                        else -> {
+                            binding.root.visibility = View.GONE
+                        }
+                    }
+                }
+            }
+        }
+
+        clickListenerForAllViews?.let { onClickListener ->
+            binding.root.allViews.forEach { it.setOnClickListener(onClickListener) }
+        }
+
+        return binding.root
+    }
+
+    private fun updateHistoryView(historyView: HistoryView) {
+        val solvedDifficulty = historyView.solvedGrids().map { it.gridInfo.classicDifficulty }
+
+        if (solvedDifficulty.isNotEmpty()) {
+            LegacyStatisticsActivity.fillChart(
+                binding.overallDifficulty,
+                solvedDifficulty,
+                solvedDifficulty.average(),
+                com.google.android.material.R.attr.colorOnPrimaryContainer,
+            )
+
+            binding.overallDifficultyMinimum.text = solvedDifficulty.min().roundToInt().toString()
+            binding.overallDifficultyAverage.text = solvedDifficulty.average().roundToInt().toString()
+            binding.overallDifficultyMaximum.text = solvedDifficulty.max().roundToInt().toString()
+        }
+    }
+}

--- a/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/statistics/StatisticsDurationDiagramFragment.kt
+++ b/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/statistics/StatisticsDurationDiagramFragment.kt
@@ -1,0 +1,79 @@
+package org.piepmeyer.gauguin.ui.statistics
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.allViews
+import androidx.fragment.app.Fragment
+import com.patrykandpatrick.vico.core.cartesian.axis.VerticalAxis
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import org.piepmeyer.gauguin.R
+import org.piepmeyer.gauguin.Utils
+import org.piepmeyer.gauguin.databinding.FragmentStatisticsDurationDiagramBinding
+import org.piepmeyer.gauguin.preferences.StatisticsManagerReading
+import org.piepmeyer.gauguin.ui.statistics.legacy.LegacyStatisticsActivity
+import kotlin.time.Duration.Companion.seconds
+
+class StatisticsDurationDiagramFragment :
+    Fragment(R.layout.fragment_statistics_duration_diagram),
+    FragmentWithClickListenerForAllViews,
+    KoinComponent {
+    lateinit var binding: FragmentStatisticsDurationDiagramBinding
+
+    override var clickListenerForAllViews: View.OnClickListener? = null
+
+    private val statisticsManager: StatisticsManagerReading by inject()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        parent: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        binding = FragmentStatisticsDurationDiagramBinding.inflate(inflater, parent, false)
+
+        val overall = statisticsManager.statistics().overall
+
+        if (overall.solvedDuration.isNotEmpty()) {
+            val durationAverage = overall.solvedDurationSum / overall.gamesSolved
+
+            LegacyStatisticsActivity.Companion.fillChart(
+                binding.overallDuration,
+                statisticsManager.statistics().overall.solvedDuration,
+                statisticsManager
+                    .statistics()
+                    .overall.solvedDuration
+                    .average(),
+                com.google.android.material.R.attr.colorSecondary,
+            )
+
+            val axis =
+                binding.overallDuration.chart!!.startAxis as VerticalAxis
+
+            binding.overallDuration.chart =
+                binding.overallDuration
+                    .chart!!
+                    .copy(
+                        startAxis =
+                            axis.copy(
+                                valueFormatter = { _, value, _ ->
+                                    Utils.displayableGameDuration(value.toInt().seconds)
+                                },
+                            ),
+                    )
+
+            binding.overallDurationMinimum.text =
+                Utils.displayableGameDuration(overall.solvedDurationMinimum.seconds)
+            binding.overallDurationAverage.text = Utils.displayableGameDuration(durationAverage.seconds)
+            binding.overallDurationMaximum.text =
+                Utils.displayableGameDuration(overall.solvedDurationMaximum.seconds)
+        }
+
+        clickListenerForAllViews?.let { onClickListener ->
+            binding.root.allViews.forEach { it.setOnClickListener(onClickListener) }
+        }
+
+        return binding.root
+    }
+}

--- a/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/statistics/StatisticsMultiDiagramFragment.kt
+++ b/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/statistics/StatisticsMultiDiagramFragment.kt
@@ -1,0 +1,55 @@
+package org.piepmeyer.gauguin.ui.statistics
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.commit
+import org.piepmeyer.gauguin.R
+import org.piepmeyer.gauguin.databinding.FragmentLegacyStatisticsMultiDiagramBinding
+
+class StatisticsMultiDiagramFragment() : Fragment(R.layout.fragment_statistics_multi_diagram) {
+    lateinit var binding: FragmentLegacyStatisticsMultiDiagramBinding
+
+    private var scatterPlotDiagramFragment: StatisticsScatterPlotDiagramFragment? = null
+    private var durationDiagramFragment: StatisticsDurationDiagramFragment? = null
+
+    constructor(
+        scatterPlotDiagramFragment: StatisticsScatterPlotDiagramFragment,
+        durationDiagramFragment: StatisticsDurationDiagramFragment,
+    ) : this() {
+        this.scatterPlotDiagramFragment = scatterPlotDiagramFragment
+        this.durationDiagramFragment = durationDiagramFragment
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        parent: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        binding = FragmentLegacyStatisticsMultiDiagramBinding.inflate(inflater, parent, false)
+
+        parentFragmentManager.commit {
+            scatterPlotDiagramFragment?.let {
+                replace(binding.multiDiagramFrameScatterPlot.id, it)
+            }
+            durationDiagramFragment?.let {
+                replace(binding.multiDiagramFrameDurationPlot.id, it)
+            }
+        }
+
+        binding.toggleGroupMultiDiagram.addOnButtonCheckedListener { _, checkedId, isChecked ->
+            if (isChecked) {
+                binding.multiDiagramFrameScatterPlot.visibility =
+                    if (checkedId == binding.toggleGroupButtonScatterPlot.id) View.VISIBLE else View.GONE
+                binding.multiDiagramFrameDurationPlot.visibility =
+                    if (checkedId == binding.toggleGroupButtonDuration.id) View.VISIBLE else View.GONE
+            }
+        }
+
+        binding.toggleGroupMultiDiagram.check(binding.toggleGroupButtonScatterPlot.id)
+
+        return binding.root
+    }
+}

--- a/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/statistics/StatisticsScatterPlotDiagramFragment.kt
+++ b/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/statistics/StatisticsScatterPlotDiagramFragment.kt
@@ -1,0 +1,151 @@
+package org.piepmeyer.gauguin.ui.statistics
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.allViews
+import androidx.fragment.app.Fragment
+import com.androidplot.util.PixelUtils
+import com.androidplot.xy.BoundaryMode
+import com.androidplot.xy.LineAndPointFormatter
+import com.androidplot.xy.SimpleXYSeries
+import com.androidplot.xy.XYGraphWidget
+import com.google.android.material.color.MaterialColors
+import org.koin.android.ext.android.inject
+import org.koin.core.component.KoinComponent
+import org.piepmeyer.gauguin.R
+import org.piepmeyer.gauguin.Utils
+import org.piepmeyer.gauguin.databinding.FragmentStatisticsScatterPlotDiagramBinding
+import org.piepmeyer.gauguin.preferences.StatisticsManagerReading
+import java.text.FieldPosition
+import java.text.Format
+import java.text.ParsePosition
+import kotlin.math.nextUp
+import kotlin.math.roundToInt
+import kotlin.time.Duration.Companion.seconds
+
+class StatisticsScatterPlotDiagramFragment :
+    Fragment(R.layout.fragment_statistics_scatter_plot_diagram),
+    FragmentWithClickListenerForAllViews,
+    KoinComponent {
+    lateinit var binding: FragmentStatisticsScatterPlotDiagramBinding
+
+    override var clickListenerForAllViews: View.OnClickListener? = null
+
+    private val statisticsManager: StatisticsManagerReading by inject()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        parent: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        binding = FragmentStatisticsScatterPlotDiagramBinding.inflate(inflater, parent, false)
+
+        if (statisticsManager
+                .statistics()
+                .overall.solvedDuration
+                .isNotEmpty()
+        ) {
+            createPlot()
+        }
+
+        clickListenerForAllViews?.let { onClickListener ->
+            binding.root.allViews.forEach { it.setOnClickListener(onClickListener) }
+        }
+
+        return binding.root
+    }
+
+    private fun createPlot() {
+        val overallSeries = SimpleXYSeries(null)
+        val lastItemSeries = SimpleXYSeries(null)
+
+        val difficultyDurationMap =
+            statisticsManager
+                .statistics()
+                .overall.solvedDuration
+                .withIndex()
+                .associateWith { statisticsManager.statistics().overall.solvedDifficulty[it.index] }
+                .toMutableMap()
+
+        val lastEntry = difficultyDurationMap.entries.last()
+        difficultyDurationMap.remove(lastEntry.key)
+
+        difficultyDurationMap.forEach { (difficulty, duration) -> overallSeries.addLast(difficulty.value, duration) }
+        lastItemSeries.addLast(lastEntry.key.value, lastEntry.value)
+
+        val maximumDuration =
+            statisticsManager
+                .statistics()
+                .overall.solvedDuration
+                .max()
+                .coerceAtLeast(60)
+        val roundedMaximumDuration = ((maximumDuration * 1.2) / 60.0).nextUp().roundToInt() * 60
+
+        val maximumDifficulty =
+            statisticsManager
+                .statistics()
+                .overall.solvedDifficulty
+                .max()
+                .nextUp()
+                .toInt()
+                .coerceAtLeast(10)
+        val roundedMaximumDifficulty = ((maximumDifficulty * 1.2) / 20.0).nextUp().roundToInt() * 20
+
+        PixelUtils.init(context)
+
+        val formatter = LineAndPointFormatter()
+        formatter.isLegendIconEnabled = false
+        formatter.fillPaint.color = 0
+        formatter.linePaint.color = 0
+        formatter.vertexPaint.color =
+            MaterialColors.getColor(binding.scatterPlot, com.google.android.material.R.attr.colorSecondary)
+        formatter.vertexPaint.strokeWidth = PixelUtils.dpToPix(10f)
+
+        val lastItemFormatter = LineAndPointFormatter()
+        lastItemFormatter.isLegendIconEnabled = false
+        lastItemFormatter.fillPaint.color = 0
+        lastItemFormatter.linePaint.color = 0
+        lastItemFormatter.vertexPaint.color =
+            MaterialColors.getColor(binding.scatterPlot, R.attr.colorCustomColor1)
+        lastItemFormatter.vertexPaint.strokeWidth = PixelUtils.dpToPix(15f)
+
+        binding.scatterPlot
+            .setDomainBoundaries(0, roundedMaximumDuration, BoundaryMode.FIXED)
+        binding.scatterPlot
+            .setRangeBoundaries(0, roundedMaximumDifficulty, BoundaryMode.FIXED)
+        binding.scatterPlot.linesPerRangeLabel = 2
+        binding.scatterPlot.rangeStepValue = 9.0
+        binding.scatterPlot.linesPerDomainLabel = 2
+        binding.scatterPlot.domainStepValue = 9.0
+
+        binding.scatterPlot.setPlotMargins(0f, 0f, 0f, 0f)
+
+        binding.scatterPlot.graph
+            .getLineLabelStyle(XYGraphWidget.Edge.BOTTOM)
+            .format =
+            object : Format() {
+                override fun format(
+                    obj: Any,
+                    toAppendTo: StringBuffer,
+                    pos: FieldPosition?,
+                ): StringBuffer {
+                    val value = (obj as Number).toFloat().roundToInt()
+
+                    return toAppendTo.append(Utils.displayableGameDuration(value.seconds))
+                }
+
+                override fun parseObject(
+                    source: String?,
+                    pos: ParsePosition?,
+                ): Any? {
+                    // unused
+                    return null
+                }
+            }
+
+        binding.scatterPlot.addSeries(overallSeries, formatter)
+        binding.scatterPlot.addSeries(lastItemSeries, lastItemFormatter)
+    }
+}

--- a/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/statistics/StatisticsStreaksDiagramFragment.kt
+++ b/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/statistics/StatisticsStreaksDiagramFragment.kt
@@ -1,0 +1,144 @@
+package org.piepmeyer.gauguin.ui.statistics
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.allViews
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.google.android.material.color.MaterialColors
+import com.patrykandpatrick.vico.core.cartesian.data.CartesianChartModel
+import com.patrykandpatrick.vico.core.cartesian.data.ColumnCartesianLayerModel
+import com.patrykandpatrick.vico.core.cartesian.layer.ColumnCartesianLayer
+import com.patrykandpatrick.vico.core.common.component.LineComponent
+import com.patrykandpatrick.vico.core.common.data.ExtraStore
+import com.patrykandpatrick.vico.views.cartesian.CartesianChartView
+import kotlinx.coroutines.launch
+import org.koin.androidx.viewmodel.ext.android.activityViewModel
+import org.koin.core.component.KoinComponent
+import org.piepmeyer.gauguin.R
+import org.piepmeyer.gauguin.databinding.FragmentStatisticsStreaksDiagramBinding
+import org.piepmeyer.gauguin.history.HistoryView
+
+class StatisticsStreaksDiagramFragment :
+    Fragment(R.layout.fragment_statistics_streaks_diagram),
+    FragmentWithClickListenerForAllViews,
+    KoinComponent {
+    lateinit var binding: FragmentStatisticsStreaksDiagramBinding
+    override var clickListenerForAllViews: View.OnClickListener? = null
+
+    private val viewModel: StatisticsViewModel by activityViewModel()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        parent: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        binding = FragmentStatisticsStreaksDiagramBinding.inflate(inflater, parent, false)
+
+        lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.historyState.collect {
+                    when (it) {
+                        is HistoryState.HistoryLoaded -> {
+                            updateHistoryView(it.view)
+                            binding.root.visibility = View.VISIBLE
+                        }
+
+                        else -> {
+                            binding.root.visibility = View.GONE
+                        }
+                    }
+                }
+            }
+        }
+
+        clickListenerForAllViews?.let { onClickListener ->
+            binding.root.allViews.forEach { it.setOnClickListener(onClickListener) }
+        }
+
+        return binding.root
+    }
+
+    private fun updateHistoryView(view: HistoryView) {
+        val streakSequence =
+            view
+                .streaks()
+                .map {
+                    if (it == 0) {
+                        0.1.toFloat()
+                    } else {
+                        it.toFloat()
+                    }
+                }.toMutableList()
+
+        val filteredStreaks =
+            streakSequence.filterIndexed { index, number ->
+                (index == streakSequence.size - 1 || index == 0) ||
+                    number == 0f ||
+                    (streakSequence[index - 1] >= number || streakSequence[index + 1] <= number)
+            }
+
+        val filledUpStreakSequence =
+            if (filteredStreaks.size >= 8) {
+                filteredStreaks
+            } else {
+                filteredStreaks + List(8 - filteredStreaks.size) { 0F }
+            }
+
+        binding.overallStreaks.setModel(
+            CartesianChartModel(
+                ColumnCartesianLayerModel.build {
+                    series(filledUpStreakSequence)
+                },
+            ),
+        )
+
+        addColorToLine(binding.overallStreaks, filteredStreaks.size - 1)
+    }
+
+    private fun addColorToLine(
+        chartView: CartesianChartView,
+        indexCurrentStreak: Int,
+    ) {
+        val formerStreaksColumn =
+            LineComponent(
+                color = MaterialColors.getColor(binding.overallStreaks, com.google.android.material.R.attr.colorSecondary),
+                thicknessDp = 8f,
+            )
+        val currentStreakColumn =
+            LineComponent(
+                color = MaterialColors.getColor(binding.overallStreaks, R.attr.colorCustomColor1),
+                thicknessDp = 8f,
+            )
+
+        with(chartView) {
+            chart =
+                chart!!.copy(
+                    (chart!!.layers[0] as ColumnCartesianLayer).copy(
+                        columnProvider = getColumnProvider(indexCurrentStreak, formerStreaksColumn, currentStreakColumn),
+                    ),
+                )
+        }
+    }
+
+    private fun getColumnProvider(
+        indexCurrentStreak: Int,
+        formerStreaksColumn: LineComponent,
+        currentStreakColumn: LineComponent,
+    ) = object : ColumnCartesianLayer.ColumnProvider {
+        override fun getColumn(
+            entry: ColumnCartesianLayerModel.Entry,
+            seriesIndex: Int,
+            extraStore: ExtraStore,
+        ) = if (entry.x.toInt() == indexCurrentStreak) currentStreakColumn else formerStreaksColumn
+
+        override fun getWidestSeriesColumn(
+            seriesIndex: Int,
+            extraStore: ExtraStore,
+        ) = formerStreaksColumn
+    }
+}

--- a/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/statistics/StatisticsViewModel.kt
+++ b/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/statistics/StatisticsViewModel.kt
@@ -1,0 +1,59 @@
+package org.piepmeyer.gauguin.ui.statistics
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.koin.core.annotation.InjectedParam
+import org.koin.core.component.KoinComponent
+import org.piepmeyer.gauguin.grid.GridSize
+import org.piepmeyer.gauguin.history.History
+import org.piepmeyer.gauguin.history.HistoryService
+import org.piepmeyer.gauguin.history.HistoryView
+
+sealed class HistoryState {
+    class HistoryLoading : HistoryState()
+
+    class HistoryEmpty : HistoryState()
+
+    class HistoryLoaded(
+        val history: History,
+        val view: HistoryView,
+    ) : HistoryState()
+}
+
+class StatisticsViewModel(
+    @InjectedParam val historyService: HistoryService,
+) : ViewModel(),
+    KoinComponent {
+    private val mutableHistoryState = MutableStateFlow<HistoryState>(HistoryState.HistoryLoading())
+
+    val historyState: StateFlow<HistoryState> = mutableHistoryState.asStateFlow()
+
+    init {
+        val history = historyService.history()
+
+        mutableHistoryState.value =
+            if (history.events.isEmpty()) {
+                HistoryState.HistoryEmpty()
+            } else {
+                HistoryState.HistoryLoaded(history, history)
+            }
+    }
+
+    fun viewOnlyOneGridSize(size: GridSize) {
+        val historyState = mutableHistoryState.value
+
+        if (historyState is HistoryState.HistoryLoaded) {
+            mutableHistoryState.value = HistoryState.HistoryLoaded(historyState.history, historyState.history.view(size))
+        }
+    }
+
+    fun viewAllSizes() {
+        val historyState = mutableHistoryState.value
+
+        if (historyState is HistoryState.HistoryLoaded) {
+            mutableHistoryState.value = HistoryState.HistoryLoaded(historyState.history, historyState.history)
+        }
+    }
+}

--- a/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/statistics/legacy/LegacyStatisticsActivity.kt
+++ b/gauguin-app/src/main/kotlin/org/piepmeyer/gauguin/ui/statistics/legacy/LegacyStatisticsActivity.kt
@@ -27,6 +27,7 @@ import org.piepmeyer.gauguin.databinding.ActivityLegacyStatisticsBinding
 import org.piepmeyer.gauguin.preferences.StatisticsManagerReading
 import org.piepmeyer.gauguin.ui.ActivityUtils
 import org.piepmeyer.gauguin.ui.statistics.FragmentWithClickListenerForAllViews
+import org.piepmeyer.gauguin.ui.statistics.StatisticsActivity
 
 class LegacyStatisticsActivity : AppCompatActivity() {
     private val activityUtils: ActivityUtils by inject()
@@ -57,6 +58,10 @@ class LegacyStatisticsActivity : AppCompatActivity() {
             resetStatisticsDialog()
         }
 
+        binding.showNewStatisticsScreen.setOnClickListener { _: View? ->
+            showNewStatisticsScreen()
+        }
+
         activityUtils.configureFullscreen(this)
 
         scatterPlotDiagramFragment = LegacyStatisticsScatterPlotDiagramFragment()
@@ -83,10 +88,10 @@ class LegacyStatisticsActivity : AppCompatActivity() {
             replace(binding.overallStreaksCardView.id, streaksDiagramFragment)
         }
 
-        setMaximizingClickistener(difficultyDiagramFragment, LegacyStatisticsMaximizeOneDiagramActivity.DiagramType.DIFFICULTY)
-        setMaximizingClickistener(streaksDiagramFragment, LegacyStatisticsMaximizeOneDiagramActivity.DiagramType.STREAKS)
-        setMaximizingClickistener(durationDiagramFragment, LegacyStatisticsMaximizeOneDiagramActivity.DiagramType.DURATION)
-        setMaximizingClickistener(scatterPlotDiagramFragment, LegacyStatisticsMaximizeOneDiagramActivity.DiagramType.SCATTER_PLOT)
+        setMaximizingClickListener(difficultyDiagramFragment, LegacyStatisticsMaximizeOneDiagramActivity.DiagramType.DIFFICULTY)
+        setMaximizingClickListener(streaksDiagramFragment, LegacyStatisticsMaximizeOneDiagramActivity.DiagramType.STREAKS)
+        setMaximizingClickListener(durationDiagramFragment, LegacyStatisticsMaximizeOneDiagramActivity.DiagramType.DURATION)
+        setMaximizingClickListener(scatterPlotDiagramFragment, LegacyStatisticsMaximizeOneDiagramActivity.DiagramType.SCATTER_PLOT)
 
         ViewCompat.setOnApplyWindowInsetsListener(
             binding.root,
@@ -107,7 +112,15 @@ class LegacyStatisticsActivity : AppCompatActivity() {
         }
     }
 
-    fun setMaximizingClickistener(
+    fun showNewStatisticsScreen() {
+        val intent = Intent(this, StatisticsActivity::class.java)
+
+        this.startActivity(intent)
+
+        finishAfterTransition()
+    }
+
+    fun setMaximizingClickListener(
         diagramFragment: FragmentWithClickListenerForAllViews,
         diagramType: LegacyStatisticsMaximizeOneDiagramActivity.DiagramType,
     ) {

--- a/gauguin-app/src/main/res/layout-land/activity_legacy_statistics.xml
+++ b/gauguin-app/src/main/res/layout-land/activity_legacy_statistics.xml
@@ -292,6 +292,16 @@
             android:text="@string/statistics_button_close"
             />
 
+        <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
+            android:id="@+id/showNewStatisticsScreen"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="New Statistics Screen"
+            app:layout_constraintTop_toTopOf="@id/statistics_close"
+            app:layout_constraintBottom_toBottomOf="@id/statistics_close"
+            app:layout_constraintEnd_toStartOf="@id/statistics_close"
+            tools:ignore="HardcodedText"
+            />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </GridLayout>

--- a/gauguin-app/src/main/res/layout-sw600dp-land/activity_legacy_statistics.xml
+++ b/gauguin-app/src/main/res/layout-sw600dp-land/activity_legacy_statistics.xml
@@ -302,6 +302,16 @@
             android:text="@string/statistics_button_close"
             />
 
+        <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
+            android:id="@+id/showNewStatisticsScreen"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="New Statistics Screen"
+            app:layout_constraintTop_toTopOf="@id/statistics_close"
+            app:layout_constraintBottom_toBottomOf="@id/statistics_close"
+            app:layout_constraintEnd_toStartOf="@id/statistics_close"
+            tools:ignore="HardcodedText"
+            />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </GridLayout>

--- a/gauguin-app/src/main/res/layout-sw600dp/activity_legacy_statistics.xml
+++ b/gauguin-app/src/main/res/layout-sw600dp/activity_legacy_statistics.xml
@@ -301,6 +301,17 @@
             android:text="@string/statistics_button_close"
             />
 
+        <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
+            android:id="@+id/showNewStatisticsScreen"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="New Statistics Screen"
+            app:layout_constraintTop_toTopOf="@id/statistics_close"
+            app:layout_constraintBottom_toBottomOf="@id/statistics_close"
+            app:layout_constraintEnd_toStartOf="@id/statistics_close"
+            tools:ignore="HardcodedText"
+            />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </GridLayout>

--- a/gauguin-app/src/main/res/layout/activity_statistics.xml
+++ b/gauguin-app/src/main/res/layout/activity_statistics.xml
@@ -8,10 +8,30 @@
     android:layout_height="fill_parent"
     >
 
+    <com.google.android.material.chip.ChipGroup
+        android:id="@+id/sizes_chip_group"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_margin="8dp"
+        app:singleSelection="true"
+        app:selectionRequired="true">
+
+        <com.google.android.material.chip.Chip
+            android:id="@+id/chip_sizes_all"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            style="@style/Widget.Material3.Chip.Filter"
+            android:text="@string/game_setting_operations_all"/>
+
+    </com.google.android.material.chip.ChipGroup>
+
     <GridLayout
         android:layout_width="fill_parent"
         android:layout_height="0dp"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/sizes_chip_group"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintBottom_toTopOf="@id/statistics_close"
@@ -143,12 +163,12 @@
             android:layout_height="0dp"
             android:layout_gravity="fill"
             android:layout_columnWeight="6"
-            android:layout_rowWeight="8"
+            android:layout_rowWeight="7"
             android:layout_margin="8dp"
             android:layout_column="4"
             android:layout_columnSpan="6"
             android:layout_row="0"
-            android:layout_rowSpan="8"
+            android:layout_rowSpan="7"
             >
 
             <TextView
@@ -289,16 +309,6 @@
         android:layout_marginStart="8dp"
         android:layout_marginEnd="8dp"
         android:text="@string/statistics_button_close"
-        />
-
-    <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
-        android:id="@+id/showNewStatisticsScreen"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="New Statistics Screen"
-        app:layout_constraintBottom_toTopOf="@id/statistics_close"
-        app:layout_constraintEnd_toEndOf="@id/statistics_close"
-        tools:ignore="HardcodedText"
         />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/gauguin-app/src/main/res/layout/fragment_statistics_difficulty_diagram.xml
+++ b/gauguin-app/src/main/res/layout/fragment_statistics_difficulty_diagram.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/overallDifficultyCardView"
+        style="?attr/materialCardViewFilledStyle"
+        android:backgroundTint="?attr/colorSurfaceContainer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        >
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <TextView
+                android:id="@+id/labelOverallDifficulty"
+                style="@style/TextAppearance.Material3.HeadlineSmall"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="8dp"
+                android:text="@string/statistics_diagram_difficulty"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                />
+
+            <com.patrykandpatrick.vico.views.cartesian.CartesianChartView
+                android:id="@+id/overallDifficulty"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                app:layers="line"
+                app:showBottomAxis="false"
+                app:showStartAxis="true"
+                app:scrollEnabled="false"
+                app:layout_constraintTop_toBottomOf="@id/labelOverallDifficulty"
+                app:layout_constraintBottom_toTopOf="@id/labelOverallDifficultyMinimum"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                />
+
+            <TextView
+                android:id="@+id/labelOverallDifficultyMinimum"
+                style="@style/TextAppearance.Material3.LabelLarge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                app:layout_constraintHorizontal_chainStyle="packed"
+                app:layout_constraintTop_toBottomOf="@id/overallDifficulty"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/overallDifficultyMinimum"
+                app:layout_constraintBottom_toBottomOf="parent"
+                android:text="@string/statistics_info_value_minimum_short" />
+
+            <TextView
+                android:id="@+id/overallDifficultyMinimum"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                app:layout_constraintTop_toBottomOf="@id/overallDifficulty"
+                app:layout_constraintStart_toEndOf="@id/labelOverallDifficultyMinimum"
+                app:layout_constraintEnd_toStartOf="@id/labelOverallDifficultyAverage"
+                />
+
+            <TextView
+                android:id="@+id/labelOverallDifficultyAverage"
+                style="@style/TextAppearance.Material3.LabelLarge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="32dp"
+                app:layout_constraintTop_toBottomOf="@id/overallDifficulty"
+                app:layout_constraintStart_toEndOf="@id/overallDifficultyMinimum"
+                app:layout_constraintEnd_toStartOf="@id/overallDifficultyAverage"
+                android:text="@string/statistics_info_value_average_short" />
+
+            <TextView
+                android:id="@+id/overallDifficultyAverage"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                app:layout_constraintTop_toBottomOf="@id/overallDifficulty"
+                app:layout_constraintStart_toEndOf="@id/labelOverallDifficultyAverage"
+                app:layout_constraintEnd_toStartOf="@id/labelOverallDifficultyMaximum"
+                />
+
+            <TextView
+                android:id="@+id/labelOverallDifficultyMaximum"
+                style="@style/TextAppearance.Material3.LabelLarge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="32dp"
+                app:layout_constraintTop_toBottomOf="@id/overallDifficulty"
+                app:layout_constraintStart_toEndOf="@id/overallDifficultyAverage"
+                app:layout_constraintEnd_toStartOf="@id/overallDifficultyMaximum"
+                android:text="@string/statistics_info_value_maximum_short" />
+
+            <TextView
+                android:id="@+id/overallDifficultyMaximum"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                app:layout_constraintTop_toBottomOf="@id/overallDifficulty"
+                app:layout_constraintStart_toEndOf="@id/labelOverallDifficultyMaximum"
+                app:layout_constraintEnd_toEndOf="parent"
+                />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/gauguin-app/src/main/res/layout/fragment_statistics_duration_diagram.xml
+++ b/gauguin-app/src/main/res/layout/fragment_statistics_duration_diagram.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/overallDurationCardView"
+        style="?attr/materialCardViewFilledStyle"
+        android:backgroundTint="?attr/colorSurfaceContainer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        >
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <TextView
+                android:id="@+id/labelOverallDuration"
+                style="@style/TextAppearance.Material3.HeadlineSmall"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="8dp"
+                android:text="@string/statistics_diagram_duration"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                />
+
+            <com.patrykandpatrick.vico.views.cartesian.CartesianChartView
+                android:id="@+id/overallDuration"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                app:layers="line"
+                app:showBottomAxis="false"
+                app:showStartAxis="true"
+                app:scrollEnabled="false"
+                app:layout_constraintTop_toBottomOf="@id/labelOverallDuration"
+                app:layout_constraintBottom_toTopOf="@id/labelOverallDurationMinimum"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                />
+
+            <TextView
+                android:id="@+id/labelOverallDurationMinimum"
+                style="@style/TextAppearance.Material3.LabelLarge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                app:layout_constraintHorizontal_chainStyle="packed"
+                app:layout_constraintTop_toBottomOf="@id/overallDuration"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/overallDurationMinimum"
+                app:layout_constraintBottom_toBottomOf="parent"
+                android:text="@string/statistics_info_value_minimum_short" />
+
+            <TextView
+                android:id="@+id/overallDurationMinimum"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                app:layout_constraintTop_toBottomOf="@id/overallDuration"
+                app:layout_constraintStart_toEndOf="@id/labelOverallDurationMinimum"
+                app:layout_constraintEnd_toStartOf="@id/labelOverallDurationAverage"
+                />
+
+            <TextView
+                android:id="@+id/labelOverallDurationAverage"
+                style="@style/TextAppearance.Material3.LabelLarge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="32dp"
+                app:layout_constraintTop_toBottomOf="@id/overallDuration"
+                app:layout_constraintStart_toEndOf="@id/overallDurationMinimum"
+                app:layout_constraintEnd_toStartOf="@id/overallDurationAverage"
+                android:text="@string/statistics_info_value_average_short" />
+
+            <TextView
+                android:id="@+id/overallDurationAverage"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                app:layout_constraintTop_toBottomOf="@id/overallDuration"
+                app:layout_constraintStart_toEndOf="@id/labelOverallDurationAverage"
+                app:layout_constraintEnd_toStartOf="@id/labelOverallDurationMaximum"
+                />
+
+            <TextView
+                android:id="@+id/labelOverallDurationMaximum"
+                style="@style/TextAppearance.Material3.LabelLarge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="32dp"
+                app:layout_constraintTop_toBottomOf="@id/overallDuration"
+                app:layout_constraintStart_toEndOf="@id/overallDurationAverage"
+                app:layout_constraintEnd_toStartOf="@id/overallDurationMaximum"
+                android:text="@string/statistics_info_value_maximum_short" />
+
+            <TextView
+                android:id="@+id/overallDurationMaximum"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                app:layout_constraintTop_toBottomOf="@id/overallDuration"
+                app:layout_constraintStart_toEndOf="@id/labelOverallDurationMaximum"
+                app:layout_constraintEnd_toEndOf="parent"
+                />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/gauguin-app/src/main/res/layout/fragment_statistics_multi_diagram.xml
+++ b/gauguin-app/src/main/res/layout/fragment_statistics_multi_diagram.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/overallDurationCardView"
+        style="?attr/materialCardViewFilledStyle"
+        android:backgroundTint="?attr/colorSurfaceContainer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        >
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <com.google.android.material.button.MaterialButtonToggleGroup
+                android:id="@+id/toggleGroupMultiDiagram"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:singleSelection="true"
+                app:selectionRequired="true"
+                >
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/toggleGroupButtonScatterPlot"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    style="?attr/materialButtonOutlinedStyle"
+                    android:text="@string/statistics_diagram_duration_and_scatter_plot_button_scatter_plot"/>
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/toggleGroupButtonDuration"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    style="?attr/materialButtonOutlinedStyle"
+                    android:text="@string/statistics_diagram_duration_and_scatter_plot_button_duration_only"/>
+
+            </com.google.android.material.button.MaterialButtonToggleGroup>
+
+            <FrameLayout
+                android:id="@+id/multiDiagramFrameScatterPlot"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/toggleGroupMultiDiagram"
+                app:layout_constraintBottom_toBottomOf="parent"
+                />
+
+            <FrameLayout
+                android:id="@+id/multiDiagramFrameDurationPlot"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/toggleGroupMultiDiagram"
+                app:layout_constraintBottom_toBottomOf="parent"
+                />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/gauguin-app/src/main/res/layout/fragment_statistics_scatter_plot_diagram.xml
+++ b/gauguin-app/src/main/res/layout/fragment_statistics_scatter_plot_diagram.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/scatterPlotCardView"
+        style="?attr/materialCardViewFilledStyle"
+        android:backgroundTint="?attr/colorSurfaceContainerHigh"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        >
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <com.androidplot.xy.XYPlot
+                android:id="@+id/scatterPlot"
+                style="@style/XYPlotAndroidPlotMaterialColors"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_marginStart="8dp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="8dp"
+                app:graphMarginTop="10dp"
+                app:graphMarginLeft="25dp"
+                app:graphMarginRight="8dp"
+                app:graphMarginBottom="25dp"
+                app:rangeTitle="@string/statistics_diagram_scatter_plot_label_difficulty"
+                app:domainTitle="@string/statistics_diagram_scatter_plot_label_duration"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/gauguin-app/src/main/res/layout/fragment_statistics_streaks_diagram.xml
+++ b/gauguin-app/src/main/res/layout/fragment_statistics_streaks_diagram.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/overallStreaksCardView"
+        style="?attr/materialCardViewFilledStyle"
+        android:backgroundTint="?attr/colorSurfaceContainer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        >
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <TextView
+                android:id="@+id/labelOverallStreaks"
+                style="@style/TextAppearance.Material3.HeadlineSmall"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="8dp"
+                android:text="@string/statistics_diagram_streaks"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                />
+
+            <com.patrykandpatrick.vico.views.cartesian.CartesianChartView
+                android:id="@+id/overallStreaks"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                app:layers="column"
+                app:showBottomAxis="false"
+                app:showStartAxis="true"
+                app:scrollEnabled="false"
+                app:layout_constraintTop_toBottomOf="@id/labelOverallStreaks"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/CoreModule.kt
+++ b/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/CoreModule.kt
@@ -14,6 +14,7 @@ import org.piepmeyer.gauguin.game.GameSolveService
 import org.piepmeyer.gauguin.game.save.CurrentGameSaver
 import org.piepmeyer.gauguin.game.save.SavedGamesService
 import org.piepmeyer.gauguin.grid.Grid
+import org.piepmeyer.gauguin.history.HistoryService
 import java.io.File
 
 class CoreModule(
@@ -73,8 +74,7 @@ class CoreModule(
                     get(),
                 )
             }
-            single {
-                GameDifficultyRatingService()
-            }
+            single { GameDifficultyRatingService() }
+            single { HistoryService() }
         }
 }

--- a/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/history/History.kt
+++ b/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/history/History.kt
@@ -1,0 +1,56 @@
+package org.piepmeyer.gauguin.history
+
+import kotlinx.serialization.Serializable
+import org.piepmeyer.gauguin.difficulty.ensureDifficultyCalculated
+import org.piepmeyer.gauguin.game.save.SavedGameOptionsVariant
+import org.piepmeyer.gauguin.grid.Grid
+import org.piepmeyer.gauguin.grid.GridSize
+import kotlin.time.Clock
+import kotlin.time.Duration
+
+class History(
+    override val events: List<HistoryEvent>,
+) : HistoryView(events) {
+    fun view(size: GridSize): HistoryView {
+        val filteredEvents = events.filter { it.gridInfo.size == size }
+
+        return HistoryView(filteredEvents)
+    }
+
+    fun gridSizes(): Set<GridSize> = events.map { it.gridInfo.size }.toSet()
+}
+
+@Serializable
+sealed class HistoryEvent(
+    open val gridInfo: GridHistoryInfo,
+) {
+    class GridSolved(
+        override val gridInfo: GridHistoryInfo,
+    ) : HistoryEvent(gridInfo)
+
+    class GridUnsolved(
+        override val gridInfo: GridHistoryInfo,
+    ) : HistoryEvent(gridInfo)
+}
+
+@Serializable
+data class GridHistoryInfo(
+    val startedAt: Long,
+    val endedAt: Long,
+    val size: GridSize,
+    val optionsVariant: SavedGameOptionsVariant,
+    val classicDifficulty: Double,
+    val duration: Duration,
+) {
+    companion object {
+        fun of(grid: Grid): GridHistoryInfo =
+            GridHistoryInfo(
+                startedAt = grid.creationDate,
+                endedAt = Clock.System.now().epochSeconds,
+                size = grid.gridSize,
+                optionsVariant = SavedGameOptionsVariant.fromOptionsVariant(grid.options),
+                classicDifficulty = grid.ensureDifficultyCalculated(),
+                duration = grid.playTime,
+            )
+    }
+}

--- a/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/history/HistoryService.kt
+++ b/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/history/HistoryService.kt
@@ -1,0 +1,19 @@
+package org.piepmeyer.gauguin.history
+
+import org.piepmeyer.gauguin.grid.Grid
+
+class HistoryService(
+    private val historyEvents: MutableList<HistoryEvent> = mutableListOf(),
+) {
+    fun history(): History = History(historyEvents)
+
+    fun gridHasBeenSolved(grid: Grid) {
+        historyEvents +=
+            HistoryEvent.GridSolved(GridHistoryInfo.of(grid))
+    }
+
+    fun gridHasBeenEndedUnsolved(grid: Grid) {
+        historyEvents +=
+            HistoryEvent.GridUnsolved(GridHistoryInfo.of(grid))
+    }
+}

--- a/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/history/HistoryView.kt
+++ b/gauguin-core/src/main/kotlin/org/piepmeyer/gauguin/history/HistoryView.kt
@@ -1,0 +1,59 @@
+package org.piepmeyer.gauguin.history
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+
+open class HistoryView(
+    open val events: List<HistoryEvent>,
+) {
+    fun playedGrids(): Int = events.size
+
+    fun playedDifficulty(): Double = events.sumOf { it.gridInfo.classicDifficulty }
+
+    fun playedDuration(): Duration =
+        events
+            .map { it.gridInfo.duration }
+            .reduceOrNull { acc, duration -> acc + duration } ?: 0.minutes
+
+    fun solvedGrids(): List<HistoryEvent> = events.filterIsInstance<HistoryEvent.GridSolved>()
+
+    fun numberOfSolvedGrids(): Int = solvedGrids().size
+
+    fun solvedDifficulty(): Double =
+        events
+            .filterIsInstance<HistoryEvent.GridSolved>()
+            .sumOf { it.gridInfo.classicDifficulty }
+
+    fun solvedDuration(): Duration =
+        events
+            .filterIsInstance<HistoryEvent.GridSolved>()
+            .map { it.gridInfo.duration }
+            .reduceOrNull { acc, duration -> acc + duration } ?: 0.minutes
+
+    fun currentStreak(): Int = events.size - events.indexOfLast { it is HistoryEvent.GridUnsolved } - 1
+
+    fun longestStreak(): Int = streaks().maxOrNull() ?: 0
+
+    fun streaks(): List<Int> {
+        val streaks = mutableListOf<Int>()
+        var currentStreak = 0
+
+        events.forEach {
+            if (it is HistoryEvent.GridSolved) {
+                currentStreak++
+            }
+
+            if (it is HistoryEvent.GridUnsolved || events.last() == it) {
+                streaks += currentStreak
+
+                if (it is HistoryEvent.GridUnsolved) {
+                    streaks += 0
+                }
+
+                currentStreak = 0
+            }
+        }
+
+        return streaks
+    }
+}

--- a/gauguin-core/src/test/kotlin/org/piepmeyer/gauguin/history/HistoryTest.kt
+++ b/gauguin-core/src/test/kotlin/org/piepmeyer/gauguin/history/HistoryTest.kt
@@ -1,0 +1,124 @@
+package org.piepmeyer.gauguin.history
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import org.piepmeyer.gauguin.game.save.SavedGameOptionsVariant
+import org.piepmeyer.gauguin.grid.GridSize
+import org.piepmeyer.gauguin.options.GameOptionsVariant
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+
+class HistoryTest :
+    FunSpec({
+
+        test("empty history") {
+            val history = History(emptyList())
+
+            history.numberOfSolvedGrids() shouldBe 0
+            history.solvedDifficulty() shouldBe 0.0
+            history.solvedDuration() shouldBe 0.minutes
+            history.playedGrids() shouldBe 0
+            history.playedDifficulty() shouldBe 0.0
+            history.playedDuration() shouldBe 0.minutes
+            history.currentStreak() shouldBe 0
+            history.longestStreak() shouldBe 0
+        }
+
+        test("single solved grid") {
+            val history =
+                History(
+                    listOf(
+                        HistoryEvent.GridSolved(historyInfo(10.0, 5.minutes)),
+                    ),
+                )
+
+            history.numberOfSolvedGrids() shouldBe 1
+            history.solvedDifficulty() shouldBe 10.0
+            history.solvedDuration() shouldBe 5.minutes
+            history.playedGrids() shouldBe 1
+            history.playedDifficulty() shouldBe 10.0
+            history.playedDuration() shouldBe 5.minutes
+            history.currentStreak() shouldBe 1
+            history.longestStreak() shouldBe 1
+        }
+
+        test("two solved grids") {
+            val history =
+                History(
+                    listOf(
+                        HistoryEvent.GridSolved(historyInfo(10.0, 5.minutes)),
+                        HistoryEvent.GridSolved(historyInfo(15.5, 7.minutes)),
+                    ),
+                )
+
+            history.numberOfSolvedGrids() shouldBe 2
+            history.solvedDifficulty() shouldBe 25.5
+            history.solvedDuration() shouldBe 12.minutes
+            history.playedGrids() shouldBe 2
+            history.playedDifficulty() shouldBe 25.5
+            history.playedDuration() shouldBe 12.minutes
+            history.currentStreak() shouldBe 2
+            history.longestStreak() shouldBe 2
+        }
+
+        test("single unsolved grid") {
+            val history =
+                History(
+                    listOf(
+                        HistoryEvent.GridUnsolved(historyInfo(10.0, 5.minutes)),
+                    ),
+                )
+
+            history.numberOfSolvedGrids() shouldBe 0
+            history.solvedDifficulty() shouldBe 0
+            history.solvedDuration() shouldBe 0.minutes
+            history.playedGrids() shouldBe 1
+            history.playedDifficulty() shouldBe 10.0
+            history.playedDuration() shouldBe 5.minutes
+            history.currentStreak() shouldBe 0
+            history.longestStreak() shouldBe 0
+        }
+
+        test("streaks solved solved unsolved solved") {
+            val history =
+                History(
+                    listOf(
+                        HistoryEvent.GridSolved(historyInfo()),
+                        HistoryEvent.GridSolved(historyInfo()),
+                        HistoryEvent.GridUnsolved(historyInfo()),
+                        HistoryEvent.GridSolved(historyInfo()),
+                    ),
+                )
+
+            history.currentStreak() shouldBe 1
+            history.longestStreak() shouldBe 2
+            history.streaks() shouldContainExactly listOf(2, 0, 1)
+        }
+
+        test("filter to grid size returns single grid") {
+            val history =
+                History(
+                    listOf(
+                        HistoryEvent.GridSolved(historyInfo(10.0, 5.minutes, GridSize(3, 3))),
+                        HistoryEvent.GridSolved(historyInfo(11.0, 6.minutes, GridSize(4, 4))),
+                        HistoryEvent.GridSolved(historyInfo(12.0, 7.minutes, GridSize(5, 5))),
+                    ),
+                ).view(size = GridSize(3, 3))
+
+            history.numberOfSolvedGrids() shouldBe 1
+            history.solvedDifficulty() shouldBe 10.0
+            history.solvedDuration() shouldBe 5.minutes
+            history.playedGrids() shouldBe 1
+            history.playedDifficulty() shouldBe 10.0
+            history.playedDuration() shouldBe 5.minutes
+        }
+    })
+
+private fun historyInfo(
+    difficulty: Double = 0.0,
+    duration: Duration = 0.minutes,
+    size: GridSize = GridSize(3, 3),
+    optionsVariant: SavedGameOptionsVariant =
+        SavedGameOptionsVariant.fromOptionsVariant(GameOptionsVariant.createClassic()),
+): GridHistoryInfo = GridHistoryInfo(0, 0, size, optionsVariant, difficulty, duration)


### PR DESCRIPTION
Currently hidden by the debug flag, thus only visible in debug builds.

This adds a history of played grids, solved and unsolved ones. The statistics are calculated from that history, so we should be able to add new statistics while utilizing the existing history data.

The existing statistics will be available in parallel, while the new statistics can populate their data.

Adds filter by grid size as first visible feature.

The current state is unfinished:
 * The history does not get stored onto disk, yet.
 * The scatter plot and duration diagram do not yet support filtering.